### PR TITLE
Fix throwing wrong error message for cannotConnectEvent errors

### DIFF
--- a/src/Instances/New.lua
+++ b/src/Instances/New.lua
@@ -118,7 +118,7 @@ local function New(className: string)
 						end) or
 						typeof(event) ~= "RBXScriptSignal"
 					then
-						logError("cannotConnectChange", nil, className, key.key)
+						logError("cannotConnectEvent", nil, className, key.key)
 					end
 
 					toConnect[event] = value

--- a/test/Instances/New.spec.lua
+++ b/test/Instances/New.spec.lua
@@ -146,7 +146,7 @@ return function()
 
 				[OnEvent "Frobulate"] = function() end
 			}
-		end).to.throw("cannotConnectChange")
+		end).to.throw("cannotConnectEvent")
 	end)
 
 	it("should throw for non-event event handlers", function()
@@ -156,7 +156,7 @@ return function()
 
 				[OnEvent "Name"] = function() end
 			}
-		end).to.throw("cannotConnectChange")
+		end).to.throw("cannotConnectEvent")
 	end)
 
 	it("shouldn't fire events during initialisation", function()


### PR DESCRIPTION
Looks like this was a copy-paste mistake. The `cannotConnectEvent` error was never thrown and `cannotConnectChange` was thrown in its place.

I have not run the unit tests since I am making this change from a library computer :)