### PR TITLE
Allow Fusion to be used as a submodule

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -1,0 +1,6 @@
+{
+    "name": "Fusion",
+    "tree": {
+        "$path": "src"
+    }
+}


### PR DESCRIPTION
Creates the `default.project.json` file to allow Rojo to use Fusion as a submodule.