### PR TITLE
Fix typings

### DIFF
--- a/src/Animation/Spring.lua
+++ b/src/Animation/Spring.lua
@@ -4,6 +4,7 @@
 ]]
 
 local Package = script.Parent.Parent
+local Types = require(Package.Types)
 local logError = require(Package.Logging.logError)
 local unpackType = require(Package.Animation.unpackType)
 local SpringScheduler = require(Package.Animation.SpringScheduler)

--- a/src/Animation/SpringScheduler.lua
+++ b/src/Animation/SpringScheduler.lua
@@ -5,6 +5,7 @@
 local RunService = game:GetService("RunService")
 
 local Package = script.Parent.Parent
+local Types = require(Package.Types)
 local packType = require(Package.Animation.packType)
 local springCoefficients = require(Package.Animation.springCoefficients)
 local updateAll = require(Package.Dependencies.updateAll)

--- a/src/Animation/Tween.lua
+++ b/src/Animation/Tween.lua
@@ -4,6 +4,7 @@
 ]]
 
 local Package = script.Parent.Parent
+local Types = require(Package.Types)
 local TweenScheduler = require(Package.Animation.TweenScheduler)
 local useDependency = require(Package.Dependencies.useDependency)
 local initDependency = require(Package.Dependencies.initDependency)

--- a/src/Animation/TweenScheduler.lua
+++ b/src/Animation/TweenScheduler.lua
@@ -5,6 +5,7 @@
 local RunService = game:GetService("RunService")
 
 local Package = script.Parent.Parent
+local Types = require(Package.Types)
 local lerpType = require(Package.Animation.lerpType)
 local getTweenRatio = require(Package.Animation.getTweenRatio)
 local updateAll = require(Package.Dependencies.updateAll)

--- a/src/State/Compat.lua
+++ b/src/State/Compat.lua
@@ -4,6 +4,7 @@
 ]]
 
 local Package = script.Parent.Parent
+local Types = require(Package.Types)
 local initDependency = require(Package.Dependencies.initDependency)
 
 local class = {}

--- a/src/Types.lua
+++ b/src/Types.lua
@@ -4,8 +4,21 @@
 
 export type Set<T> = {[T]: any}
 
-export type State<T> = {get: (State<T>) -> T}
+export type State<T> = {
+  get: (State<T>, asDependency: boolean?) -> T,
+  set: (State<T>, newValue: any, force: boolean?) -> ()
+}
 export type StateOrValue<T> = State<T> | T
+
+export type Computed<T> = {
+  get: (Computed<T>, asDependency: boolean?) -> T,
+  update: (Computed<T>) -> boolean
+}
+
+export type Compat = {
+  update: (Compat) -> boolean,
+  onChange: (Compat, callback: () -> ()) -> ()
+}
 
 export type Symbol = {
 	type: string,
@@ -47,5 +60,23 @@ export type Animatable =
 	Vector2int16 |
 	Vector3 |
 	Vector3int16
+
+export type Tween<T> = {
+	get: (Tween<T>, asDependency: boolean?) -> State<T>,
+	update: (Tween<T>) -> (),
+	-- Uncomment when ENABLE_PARAM_SETTERS is enabled
+	-- setTweenInfo: (Tween<T>, newTweenInfo: TweenInfo) -> ()
+}
+
+export type Spring<T> = {
+	get: (Spring<T>, asDependency: boolean?) -> any,
+	update: (Spring<T>) -> (),
+	-- Uncomment when ENABLE_PARAM_SETTERS is enabled
+	-- setDamping: (Spring<T>, damping: number) -> (),
+	-- setSpeed: (Spring<T>, speed: number) -> (),
+	-- setPosition: (Spring<T>, newValue: Animatable) -> (),
+	-- setVelocity: (Spring<T>, newValue: Animatable) -> (),
+	-- addVelocity: (Spring<T>, deltaValue: Animatable) -> ()
+}
 
 return nil

--- a/src/init.lua
+++ b/src/init.lua
@@ -5,9 +5,28 @@
 local Types = require(script.Types)
 local restrictRead = require(script.Utility.restrictRead)
 
-export type State = Types.State
-export type StateOrValue = Types.StateOrValue
+export type State<T> = Types.State<T>
+export type StateOrValue<T> = Types.StateOrValue<T>
 export type Symbol = Types.Symbol
+export type Computed<T> = Types.Computed<T>
+export type Compat = Types.Compat
+export type Tween<T> = Types.Tween<T>
+export type Spring<T> = Types.Spring<T>
+
+type Fusion = {
+  New: (className: string) -> ((propertyTable: {[string | Types.Symbol]: any}) -> Instance | nil),
+  Children: Types.Symbol,
+  OnEvent: (eventName: string) -> Types.Symbol,
+  OnChange: (propertyName: string) -> Types.Symbol,
+
+  State: (initialValue: any) -> State<any>,
+  Computed: (callback: () -> any) -> Computed<any>,
+  ComputedPairs: (inputTable: Types.StateOrValue<{[any]: any}>, processor: (any) -> any, destructor: (any) -> ()?) -> Computed<any>,
+  Compat: (watchedState: Types.State<any>) -> Compat,
+
+  Tween: (goalState: Types.State<Types.Animatable>, tweenInfo: TweenInfo?) -> Tween<any>,
+  Spring: (goalState: Types.State<Types.Animatable>, speed: number?, damping: number?) -> Spring<any>
+}
 
 return restrictRead("Fusion", {
 	New = require(script.Instances.New),
@@ -22,4 +41,4 @@ return restrictRead("Fusion", {
 
 	Tween = require(script.Animation.Tween),
 	Spring = require(script.Animation.Spring)
-})
+}) :: Fusion


### PR DESCRIPTION
Currently, Fusion exports a table which is returned by `restrictRead` to prevent unknown member access.

This leads to the issue that typings from the table get fully removed and gets treated as just a table without any information of the table members (Roblox marks this as `*unknown*`, Roblox LSP marks it as `any`).

![image](https://user-images.githubusercontent.com/30000694/132094407-af42d78b-3010-4e93-9a96-5bfaeeae946e.png)

This PR adds more typings for all exported members of Fusion, as well as fixes the existing exported types and the files that depend on some types but did not require them yet.

![image](https://user-images.githubusercontent.com/30000694/132095044-9590600e-6eb8-4980-b9d9-38e761eef711.png)
![image](https://user-images.githubusercontent.com/30000694/132095052-5b86199d-9523-499e-859d-e1396f506a80.png)

