### PR TITLE
Fix the Tween class

### DIFF
--- a/src/Animation/Tween.lua
+++ b/src/Animation/Tween.lua
@@ -41,7 +41,7 @@ function class:update()
 	if self._tweenInfo.Reverses then
 		tweenDuration += self._tweenInfo.Time
 	end
-	tweenDuration *= self._tweenInfo.RepeatCount
+	tweenDuration *= math.max(self._tweenInfo.RepeatCount, 1)
 	self._currentTweenDuration = tweenDuration
 
 	-- start animating this tween

--- a/src/Animation/getTweenRatio.lua
+++ b/src/Animation/getTweenRatio.lua
@@ -18,7 +18,7 @@ local function getTweenRatio(tweenInfo: TweenInfo, currentTime: number): number
 		cycleDuration += duration
 	end
 
-	if currentTime >= cycleDuration * numRepeats then
+	if currentTime >= cycleDuration * math.max(numRepeats, 1) then
 		return 1
 	end
 


### PR DESCRIPTION
Currently, when using `Tween` with a `TweenInfo` that has a `RepeatCount` of 0, it multiplies all calculations that use it by 0, making it tween to the goal value instantly instead of over the supplied time.

This PR adds `math.max(RepeatCount, 1)` to ensure that it's always multiplied by at least 1 or higher to ensure it tweens regardless of value.