### PR TITLE
Change example code to respect sensible defaults

### DIFF
--- a/docs/tutorials/fundamentals/creating-ui.md
+++ b/docs/tutorials/fundamentals/creating-ui.md
@@ -89,8 +89,8 @@ Now, we can use the `New` function like we did in the snippet above. We want to
 create a ScreenGui with these properties:
 
 - a name of 'MyFirstGui'
-- `ResetOnSpawn` disabled
-- the `ZIndexBehavior` set to 'Sibling'
+- ``ResetOnSpawn`` disabled
+- the ``ZIndexBehavior`` set to 'Sibling'
 - parented to our PlayerGui
 
 ??? question "What do these properties do?"
@@ -111,11 +111,11 @@ local New = Fusion.New
 local gui = New "ScreenGui" {
 	Parent = Players.LocalPlayer.PlayerGui,
 
-	Name = "MyFirstGui",
-	ResetOnSpawn = false,
-	ZIndexBehavior = "Sibling"
+	Name = "MyFirstGui"
 }
 ```
+
+``ZIndexBehavior`` and ``ResetOnSpawn`` are automatically set to ``Sibling`` and ``false`` by Fusion respectively. [You can check other sensible defaults here](https://elttob.github.io/Fusion/api-reference/api/new/#default-properties)
 
 If you press 'Play', you should see that a ScreenGui has appeared in your
 PlayerGui, with all of the properties we've set:

--- a/docs/tutorials/fundamentals/creating-ui.md
+++ b/docs/tutorials/fundamentals/creating-ui.md
@@ -89,8 +89,8 @@ Now, we can use the `New` function like we did in the snippet above. We want to
 create a ScreenGui with these properties:
 
 - a name of 'MyFirstGui'
-- ``ResetOnSpawn`` disabled
-- the ``ZIndexBehavior`` set to 'Sibling'
+- `ResetOnSpawn` disabled
+- the `ZIndexBehavior` set to 'Sibling'
 - parented to our PlayerGui
 
 ??? question "What do these properties do?"
@@ -115,7 +115,7 @@ local gui = New "ScreenGui" {
 }
 ```
 
-``ZIndexBehavior`` and ``ResetOnSpawn`` are automatically set to ``Sibling`` and ``false`` by Fusion respectively. [You can check other sensible defaults here](https://elttob.github.io/Fusion/api-reference/api/new/#default-properties)
+`ZIndexBehavior` and `ResetOnSpawn` are automatically set to `Sibling` and `false` by Fusion respectively. [You can check other sensible defaults here](https://elttob.github.io/Fusion/api-reference/api/new/#default-properties)
 
 If you press 'Play', you should see that a ScreenGui has appeared in your
 PlayerGui, with all of the properties we've set:


### PR DESCRIPTION
The code on https://elttob.github.io/Fusion/tutorials/fundamentals/creating-ui/ makes no mention of Sensible Defaults. I've made a fork to this document to respect it. There's probably other cases of this around the documentation.