### PR TITLE
Update incorrect api-reference

### DIFF
--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -41,4 +41,4 @@ Jump directly to the documentation for some common APIs:
 
 ### Animation
 - [Tween](api/tween)
-- [Spring](api/tween)
+- [Spring](api/spring)


### PR DESCRIPTION
The documentation link for springs is incorrect. Added change to ensure they link to the correct page.