### PR TITLE
Spring finished

### DIFF
--- a/src/Animation/Spring.lua
+++ b/src/Animation/Spring.lua
@@ -65,6 +65,8 @@ function class:update()
 
 	else
 		-- goal change - reconfigure spring to target new goal
+		self._finished = false
+
 		local oldType = self._currentType
 		local newType = typeof(goalValue)
 
@@ -204,6 +206,7 @@ local function Spring(
 		-- if we held strong references to the dependents, then they wouldn't be
 		-- able to get garbage collected when they fall out of scope
 		dependentSet = setmetatable({}, WEAK_KEYS_METATABLE),
+		_finished = true,
 		_speed = speed,
 		_speedIsState = speedIsState,
 		_lastSpeed = nil,

--- a/src/Animation/Spring.lua
+++ b/src/Animation/Spring.lua
@@ -31,6 +31,17 @@ function class:get(asDependency: boolean?)
 end
 
 --[[
+	Returns the current _finished state of the Spring object.
+	The object will be registered as a dependency unless `asDependency` is false.
+]]
+function class:isFinished(asDependency: boolean?)
+	if asDependency ~= false then
+		useDependency(self)
+	end
+	return self._finished
+end
+
+--[[
 	Called when the goal state changes value, or when the speed or damping has
 	changed.
 

--- a/src/Animation/SpringScheduler.lua
+++ b/src/Animation/SpringScheduler.lua
@@ -132,13 +132,17 @@ local function updateAllSprings(timeStep: number)
 						isMoving = true
 					end
 
-					positions[index] = newDisplacement + goal
+					positions[index] = isMoving and newDisplacement + goal or goal
 					velocities[index] = newVelocity
 				end
 
 				-- if the spring moved a significant distance, update its
 				-- current value, otherwise stop animating
-				if isMoving then
+				if not spring._finished then
+					if not isMoving then
+						spring._finished = true
+					end
+					
 					spring._currentValue = packType(positions, spring._currentType)
 					updateAll(spring)
 				else

--- a/src/Types.lua
+++ b/src/Types.lua
@@ -71,6 +71,7 @@ export type Tween<T> = {
 
 export type Spring<T> = {
 	get: (Spring<T>, asDependency: boolean?) -> any,
+	isFinished: (Spring<T>, asDependency: boolean?) -> boolean,
 	update: (Spring<T>) -> (),
 	-- Uncomment when ENABLE_PARAM_SETTERS is enabled
 	-- setDamping: (Spring<T>, damping: number) -> (),


### PR DESCRIPTION
I was testing out animations for ui using springs and couldn't find a good way to check for when the spring stops moving/finishes.

My first attempt was to check the size of the ui and compare it to the goal, but that method uses code outside of Fusion to succeed.

Second try was to set up a Computed state that checks the spring:get() and compares it to the goal ui and turns Visible to false once the value of spring:get() == the end goal:
```lua
local val = State(0)
local spring = Spring(val, 5, .5)
local goal = 100

local ui = New "Frame" {
    Visible = Computed(function() return spring:get() ~= goal end)
}

val:set(goal)
```

With this I thought it would work perfectly since once the spring finished, it would = 100 right? Well actually, the spring ended up equaling ~100.0001 because of the value of `MOVEMENT_EPSILON`.

So I decided to dig into the `MOVEMENT_EPSILON` and figure out a way I could use that.

First I saw that the spring was only being updated by `updateAll(spring)` when `isMoving` is true in the SpringScheduler module. So I came up with a way to have it update the spring one last time when `isMoving` is finally set to true by adding another key to the spring table:
`_finished = true`
With this you can set the finished state to true while also updating the spring's value one last time. Now it's not necessary to do `positions[index] = isMoving and newDisplacement + goal or goal`, but I added that in so that once the spring is completed, the value stored in the spring is always the goal value, so the last update will return the end goal to the :get() calls.

And now all you have to do is:
```lua
local val = State(0)
local spring = Spring(val, 5, .5)
local goal = 100

local ui = New "Frame" {
    Visible = Computed(function() return not spring:isFinished() end)
}

val:set(goal)
```
And Visible will turned off once the spring is finished

Related Issue: #82 