### PR TITLE
Update old State typing to Value

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -10,7 +10,7 @@ local restrictRead = require(script.Utility.restrictRead)
 export type StateObject<T> = PubTypes.StateObject<T>
 export type CanBeState<T> = PubTypes.CanBeState<T>
 export type Symbol = PubTypes.Symbol
-export type State<T> = PubTypes.State<T>
+export type Value<T> = PubTypes.Value<T>
 export type Computed<T> = PubTypes.Computed<T>
 export type ComputedPairs<K, V> = PubTypes.ComputedPairs<K, V>
 export type Observer = PubTypes.Observer
@@ -23,7 +23,7 @@ type Fusion = {
 	OnEvent: (eventName: string) -> PubTypes.OnEventKey,
 	OnChange: (propertyName: string) -> PubTypes.OnChangeKey,
 
-	State: <T>(initialValue: T) -> State<T>,
+	Value: <T>(initialValue: T) -> Value<T>,
 	Computed: <T>(callback: () -> T) -> Computed<T>,
 	ComputedPairs: <K, VI, VO>(inputTable: CanBeState<{[K]: VI}>, processor: (K, VI) -> VO, destructor: (VO) -> ()?) -> ComputedPairs<K, VO>,
 	Observer: (watchedState: StateObject<any>) -> Observer,


### PR DESCRIPTION
A quick 2 line change- when updating my codebase to use the latest version I found that the typing for Fusion still used State instead of Value and would warn that PubTypes no longer exported anything called State.