### PR TITLE
Create new error message for invalid property type

### DIFF
--- a/src/Instances/New.lua
+++ b/src/Instances/New.lua
@@ -72,7 +72,7 @@ local function New(className: string)
 				-- Properties bound to state
 				if typeof(value) == "table" and value.type == "State" then
 					local existingValue, attemptedValue
-					local assignOK = pcall(function()
+					local assignOK, errorMessage = pcall(function()
 						-- store values for error reporting
 						existingValue = ref.instance[key]
 						attemptedValue = value:get(false)
@@ -82,7 +82,7 @@ local function New(className: string)
 					end)
 					
 					if not assignOK then
-						if existingValue ~= nil then
+						if existingValue ~= nil or errorMessage:find("invalid") ~= nil then
 							logError("invalidPropertyType", nil, className, key, typeof(attemptedValue), typeof(existingValue))
 						else
 							logError("cannotAssignProperty", nil, className, key)
@@ -107,7 +107,7 @@ local function New(className: string)
 				-- Properties with constant values
 				else
 					local existingValue
-					local assignOK = pcall(function()
+					local assignOK, errorMessage = pcall(function()
 						-- store values for error reporting
 						existingValue = ref.instance[key]
 
@@ -116,7 +116,7 @@ local function New(className: string)
 					end)
 					
 					if not assignOK then
-						if existingValue ~= nil then
+						if existingValue ~= nil or errorMessage:find("invalid") ~= nil then
 							logError("invalidPropertyType", nil, className, key, typeof(value), typeof(existingValue))
 						else
 							logError("cannotAssignProperty", nil, className, key)
@@ -293,7 +293,7 @@ local function New(className: string)
 				end)
 
 				if not assignOK then
-					logError("cannotAssignProperty", nil, className, "Parent")
+					logError("invalidPropertyType", nil, className, "Parent", typeof(parent:get(false)), "Instance")
 				end
 
 				table.insert(cleanupTasks,
@@ -319,7 +319,7 @@ local function New(className: string)
 				end)
 
 				if not assignOK then
-					logError("cannotAssignProperty", nil, className, "Parent")
+					logError("invalidPropertyType", nil, className, "Parent", typeof(parent), "Instance")
 				end
 			end
 		end

--- a/src/Instances/New.lua
+++ b/src/Instances/New.lua
@@ -71,17 +71,17 @@ local function New(className: string)
 
 				-- Properties bound to state
 				if typeof(value) == "table" and value.type == "State" then
-					local existingValue, attemptedValue
 					local assignOK, errorMessage = pcall(function()
-						-- store values for error reporting
-						existingValue = ref.instance[key]
-						attemptedValue = value:get(false)
-
-						-- set value
-						ref.instance[key] = attemptedValue
+						ref.instance[key] = value:get(false)
 					end)
 					
 					if not assignOK then
+						local existingValue, attemptedValue
+						pcall(function()
+							existingValue = ref.instance[key]
+							attemptedValue = value:get(false)
+						end)
+
 						if existingValue ~= nil or errorMessage:find("invalid") ~= nil then
 							logError("invalidPropertyType", nil, className, key, typeof(attemptedValue), typeof(existingValue))
 						else
@@ -106,16 +106,16 @@ local function New(className: string)
 
 				-- Properties with constant values
 				else
-					local existingValue
 					local assignOK, errorMessage = pcall(function()
-						-- store values for error reporting
-						existingValue = ref.instance[key]
-
-						-- set value
 						ref.instance[key] = value
 					end)
 					
 					if not assignOK then
+						local existingValue
+						pcall(function()
+							existingValue = ref.instance[key]
+						end)
+
 						if existingValue ~= nil or errorMessage:find("invalid") ~= nil then
 							logError("invalidPropertyType", nil, className, key, typeof(value), typeof(existingValue))
 						else

--- a/src/Instances/New.lua
+++ b/src/Instances/New.lua
@@ -83,7 +83,7 @@ local function New(className: string)
 						end)
 
 						if existingValue ~= nil or errorMessage:find("invalid") ~= nil then
-							logError("invalidPropertyType", nil, className, key, typeof(attemptedValue), typeof(existingValue))
+							logError("invalidPropertyType", nil, key, typeof(attemptedValue), typeof(existingValue), className)
 						else
 							logError("cannotAssignProperty", nil, className, key)
 						end
@@ -117,7 +117,7 @@ local function New(className: string)
 						end)
 
 						if existingValue ~= nil or errorMessage:find("invalid") ~= nil then
-							logError("invalidPropertyType", nil, className, key, typeof(value), typeof(existingValue))
+							logError("invalidPropertyType", nil, key, typeof(value), typeof(existingValue), className)
 						else
 							logError("cannotAssignProperty", nil, className, key)
 						end
@@ -293,7 +293,7 @@ local function New(className: string)
 				end)
 
 				if not assignOK then
-					logError("invalidPropertyType", nil, className, "Parent", typeof(parent:get(false)), "Instance")
+					logError("invalidPropertyType", nil, "Parent", typeof(parent:get(false)), "Instance", className)
 				end
 
 				table.insert(cleanupTasks,
@@ -319,7 +319,7 @@ local function New(className: string)
 				end)
 
 				if not assignOK then
-					logError("invalidPropertyType", nil, className, "Parent", typeof(parent), "Instance")
+					logError("invalidPropertyType", nil, "Parent", typeof(parent), "Instance", className)
 				end
 			end
 		end

--- a/src/Instances/New.lua
+++ b/src/Instances/New.lua
@@ -71,12 +71,22 @@ local function New(className: string)
 
 				-- Properties bound to state
 				if typeof(value) == "table" and value.type == "State" then
+					local existingValue, attemptedValue
 					local assignOK = pcall(function()
-						ref.instance[key] = value:get(false)
-					end)
+						-- store values for error reporting
+						existingValue = ref.instance[key]
+						attemptedValue = value:get(false)
 
+						-- set value
+						ref.instance[key] = attemptedValue
+					end)
+					
 					if not assignOK then
-						logError("cannotAssignProperty", nil, className, key)
+						if existingValue ~= nil then
+							logError("invalidPropertyType", nil, className, key, typeof(attemptedValue), typeof(existingValue))
+						else
+							logError("cannotAssignProperty", nil, className, key)
+						end
 					end
 
 					local disconnect = Observer(value):onChange(function()
@@ -96,12 +106,21 @@ local function New(className: string)
 
 				-- Properties with constant values
 				else
+					local existingValue
 					local assignOK = pcall(function()
+						-- store values for error reporting
+						existingValue = ref.instance[key]
+
+						-- set value
 						ref.instance[key] = value
 					end)
-
+					
 					if not assignOK then
-						logError("cannotAssignProperty", nil, className, key)
+						if existingValue ~= nil then
+							logError("invalidPropertyType", nil, className, key, typeof(value), typeof(existingValue))
+						else
+							logError("cannotAssignProperty", nil, className, key)
+						end
 					end
 				end
 

--- a/src/Logging/messages.lua
+++ b/src/Logging/messages.lua
@@ -10,6 +10,7 @@ return {
 	cannotConnectEvent = "The %s class doesn't have an event called '%s'.",
 	cannotCreateClass = "Can't create a new instance of class '%s'.",
 	computedCallbackError = "Computed callback error: ERROR_MESSAGE",
+	invalidPropertyType = "The class type '%s' has property '%s', but you attempted to set it to a '%s', while it expected a '%s'.",
 	invalidSpringDamping = "The damping ratio for a spring must be >= 0. (damping was %.2f)",
 	invalidSpringSpeed = "The speed of a spring must be >= 0. (speed was %.2f)",
 	mistypedSpringDamping = "The damping ratio for a spring must be a number. (got a %s)",

--- a/src/Logging/messages.lua
+++ b/src/Logging/messages.lua
@@ -10,7 +10,7 @@ return {
 	cannotConnectEvent = "The %s class doesn't have an event called '%s'.",
 	cannotCreateClass = "Can't create a new instance of class '%s'.",
 	computedCallbackError = "Computed callback error: ERROR_MESSAGE",
-	invalidPropertyType = "The class type '%s' has property '%s', but you attempted to set it to a '%s', while it expected a '%s'.",
+	invalidPropertyType = "'%s' expected a '%s', but got a '%s' (for class '%s')",
 	invalidSpringDamping = "The damping ratio for a spring must be >= 0. (damping was %.2f)",
 	invalidSpringSpeed = "The speed of a spring must be >= 0. (speed was %.2f)",
 	mistypedSpringDamping = "The damping ratio for a spring must be a number. (got a %s)",

--- a/test/Instances/New.spec.lua
+++ b/test/Instances/New.spec.lua
@@ -56,21 +56,55 @@ return function()
 		end).to.throw("cannotAssignProperty")
 	end)
 
-	it("should throw on invalid constant property type", function()
+	it("should throw on invalid property type for non-Parent", function()
 		expect(function()
 			New "Folder" {
 				Name = UDim.new()
 			}
 		end).to.throw("invalidPropertyType")
-	end)
 
-	it("should throw on invalid value property type", function()
 		local state = Value(true)
 
 		expect(function()
 			New "Folder" {
 				Name = Computed(function()
 					state:get()
+				end)
+			}
+		end).to.throw("invalidPropertyType")
+	end)
+
+	it("should throw on invalid property type for Parent", function()
+		expect(function()
+			New "Folder" {
+				Parent = "Foo"
+			}
+		end).to.throw("invalidPropertyType")
+
+		local state = Value(true)
+
+		expect(function()
+			New "Folder" {
+				Parent = Computed(function()
+					return state:get()
+				end)
+			}
+		end).to.throw("invalidPropertyType")
+	end)
+
+	it("should throw on invalid property type for Instances", function()
+		expect(function()
+			New "ObjectValue" {
+				Value = "Foo"
+			}
+		end).to.throw("invalidPropertyType")
+
+		local state = Value(true)
+
+		expect(function()
+			New "ObjectValue" {
+				Value = Computed(function()
+					return state:get()
 				end)
 			}
 		end).to.throw("invalidPropertyType")

--- a/test/Instances/New.spec.lua
+++ b/test/Instances/New.spec.lua
@@ -36,7 +36,7 @@ return function()
 		expect(ins.Name).to.equal("Bob")
 	end)
 
-	it("should throw for non-existent properties", function()
+	it("should throw for non-existent constant properties", function()
 		expect(function()
 			New "Folder" {
 				Frobulator = "Frobulateur"
@@ -44,10 +44,34 @@ return function()
 		end).to.throw("cannotAssignProperty")
 	end)
 
-	it("should throw for invalid property type", function()
+	it("should throw for non-existent value properties", function()
+		local state = Value("Frobulateur")
+
+		expect(function()
+			New "Folder" {
+				Frobulator = Computed(function()
+					state:get()
+				end)
+			}
+		end).to.throw("cannotAssignProperty")
+	end)
+
+	it("should throw on invalid constant property type", function()
 		expect(function()
 			New "Folder" {
 				Name = UDim.new()
+			}
+		end).to.throw("invalidPropertyType")
+	end)
+
+	it("should throw on invalid value property type", function()
+		local state = Value(true)
+
+		expect(function()
+			New "Folder" {
+				Name = Computed(function()
+					state:get()
+				end)
 			}
 		end).to.throw("invalidPropertyType")
 	end)

--- a/test/Instances/New.spec.lua
+++ b/test/Instances/New.spec.lua
@@ -44,6 +44,14 @@ return function()
 		end).to.throw("cannotAssignProperty")
 	end)
 
+	it("should throw for invalid property type", function()
+		expect(function()
+			New "Folder" {
+				Name = UDim.new()
+			}
+		end).to.throw("invalidPropertyType")
+	end)
+
 	it("should throw for unrecognised keys", function()
 		expect(function()
 			New "Folder" {

--- a/test/Utility/cleanupOnDestroy.spec.lua
+++ b/test/Utility/cleanupOnDestroy.spec.lua
@@ -22,7 +22,7 @@ return function()
 		ins:Destroy()
 
 		local start = os.clock()
-		local timeout = 2
+		local timeout = 3
 
 		repeat
 			RunService.RenderStepped:Wait()
@@ -44,7 +44,7 @@ return function()
 		ins:Destroy()
 
 		local start = os.clock()
-		local timeout = 2
+		local timeout = 3
 
 		repeat
 			RunService.RenderStepped:Wait()
@@ -66,7 +66,7 @@ return function()
 		end
 
 		local start = os.clock()
-		local timeout = 2
+		local timeout = 3
 
 		repeat
 			RunService.RenderStepped:Wait()
@@ -88,7 +88,7 @@ return function()
 		end
 
 		local start = os.clock()
-		local timeout = 2
+		local timeout = 3
 
 		repeat
 			RunService.RenderStepped:Wait()
@@ -111,7 +111,7 @@ return function()
 		ins.Parent = nil
 
 		local start = os.clock()
-		local timeout = 2
+		local timeout = 3
 
 		repeat
 			RunService.RenderStepped:Wait()


### PR DESCRIPTION
Solves #22. Added additional unit tests, 2 cover the addition of the ``invalidPropertyType`` error, and its edge cases. The ``cannotAssignProperty`` error was missing unit testing coverage for Values, and since this PR addresses issues with the ``cannotAssignProperty`` error, I added additional coverage for Values. (note, here by Values I mean the ``Value`` class of Fusion. This distinction is helpful because I added ObjectValue unit testing to check for edge cases)

Something I would like to note is that as I kept adding more unit tests, ``cleanupOnDestroy.spec``'s unit tests started throwing errors. It would appear that it depends on the speed of the rest of the unit testing and needs to be looked into. I temporarily circumvented this problem by bumping its timeout to 3 seconds instead of 2. I also opened an issue for this (#101).

Unit testing for this passed: https://github.com/nottirb/Fusion/runs/4571710080?check_suite_focus=true