### PR TITLE
Update cleanupOnDestroy_smart?

### DIFF
--- a/src/Instances/New.lua
+++ b/src/Instances/New.lua
@@ -7,7 +7,7 @@
 
 local Package = script.Parent.Parent
 local PubTypes = require(Package.PubTypes)
-local cleanupOnDestroy = require(Package.Utility.cleanupOnDestroy_smart)
+local cleanupOnDestroy = require(Package.Utility.cleanupOnDestroy)
 local Children = require(Package.Instances.Children)
 local Ref = require(Package.Instances.Ref)
 local Scheduler = require(Package.Instances.Scheduler)

--- a/src/Instances/New.lua
+++ b/src/Instances/New.lua
@@ -7,7 +7,7 @@
 
 local Package = script.Parent.Parent
 local PubTypes = require(Package.PubTypes)
-local cleanupOnDestroy = require(Package.Utility.cleanupOnDestroy)
+local cleanupOnDestroy = require(Package.Utility.cleanupOnDestroy_smart)
 local Children = require(Package.Instances.Children)
 local Ref = require(Package.Instances.Ref)
 local Scheduler = require(Package.Instances.Scheduler)

--- a/src/Utility/cleanupOnDestroy_smart.lua
+++ b/src/Utility/cleanupOnDestroy_smart.lua
@@ -45,7 +45,7 @@ local function cleanupOnDestroy(instance: Instance?, cleanupTask: cleanup.Task):
 	local isNilParented = (instance :: Instance).Parent == nil
 	local parentTreeSize = 0
 
-	local function calculateFromTree(child: Instance)
+	local function calculateFromTree(child: Instance?)
 		parentTreeSize = 0
 
 		local finished = child == nil or child == game
@@ -55,7 +55,7 @@ local function cleanupOnDestroy(instance: Instance?, cleanupTask: cleanup.Task):
 		else
 			while finished == false do
 				parentTreeSize += 1
-				local parent = child.Parent
+				local parent: Instance? = child and child.Parent or nil
 	
 				if parent == nil or parent == game then
 					if child then
@@ -76,10 +76,7 @@ local function cleanupOnDestroy(instance: Instance?, cleanupTask: cleanup.Task):
 				child = parent
 			end
 		end
-
-		if child == nil and not isNilParented and parentTreeSize > 0 then
-			print("Detected nil where it otherwise wouldn't")
-		end
+		
 		isNilParented = child == nil
 		child = nil
 	end

--- a/src/Utility/cleanupOnDestroy_smart.lua
+++ b/src/Utility/cleanupOnDestroy_smart.lua
@@ -18,89 +18,35 @@ local cleanup = require(Package.Utility.cleanup)
 -- The event to use for waiting (typically Heartbeat)
 local STEP_EVENT = RunService.Heartbeat
 
-local function noOp()
-	-- intentionally blank - no operation!
-end
-
-local function cleanupOnDestroy(instance: Instance?, cleanupTask: cleanup.Task): (() -> ())
+local function cleanupOnDestroy(instance: Instance?, task: cleanup.Task): (() -> ())
 	-- set up manual disconnection logic
 	local isDisconnected = false
-	local ancestryChangedConn, highTierConn
-	local ignoreHighTierConn = true
+	local ancestryChangedConn
 
 	local function disconnect()
 		if not isDisconnected then
 			isDisconnected = true
 			ancestryChangedConn:Disconnect()
-
-			if highTierConn and highTierConn.Connected ~= nil then
-				highTierConn:Disconnect()
-			end
 		end
 	end
 
 	-- We can't keep a reference to the instance, but we need to keep track of
 	-- when the instance is parented to `nil`.
 	-- To get around this, we can save the parent from AncestryChanged here
-	local isNilParented = (instance :: Instance).Parent == nil
-	local parentTreeSize = 0
-
-	local function calculateFromTree(child: Instance?)
-		parentTreeSize = 0
-
-		local finished = child == nil or child == game
-
-		if finished then
-			ignoreHighTierConn = true
-		else
-			while finished == false do
-				parentTreeSize += 1
-				local parent: Instance? = child and child.Parent or nil
-	
-				if parent == nil or parent == game then
-					if child then
-						if highTierConn then
-							highTierConn:Disconnect()
-						end
-	
-						highTierConn = child:GetPropertyChangedSignal("ClassName"):Connect(noOp)
-						ignoreHighTierConn = false
-	
-					else
-						ignoreHighTierConn = true
-					end
-					
-					finished = true
-				end
-	
-				child = parent
-			end
-		end
-		
-		isNilParented = child == nil
-		child = nil
-	end
-	
-	calculateFromTree(instance :: Instance)
+	local isNilParented = if instance then not game:IsAncestorOf(instance :: Instance) else false
 
 	-- when AncestryChanged is called, run some destroy-checking logic
 	-- this function can yield when called, so make sure to call in a new thread
 	-- if you don't want your current thread to block
 	local function onInstanceMove(_doNotUse: Instance?, newParent: Instance?)
-		local oldParentTreeSize = parentTreeSize
-
-		-- discard the first argument so we don't inhibit GC
 		if isDisconnected then
-			_doNotUse = nil
 			return
-			
-		else
-			-- determine how many objects there are until we reach `nil` or `game`
-			calculateFromTree(_doNotUse)
-			_doNotUse = nil
 		end
 
-		--isNilParented = newParent == nil
+		-- discard the first argument so we don't inhibit GC
+		_doNotUse = nil
+
+		isNilParented = not game:IsAncestorOf(newParent)
 
 		-- if the instance has been moved into a nil parent, it could possibly
 		-- have been destroyed if no other references exist
@@ -118,7 +64,7 @@ local function cleanupOnDestroy(instance: Instance?, cleanupTask: cleanup.Task):
 
 				elseif not ancestryChangedConn.Connected then
 					-- if our event was disconnected, the instance was destroyed
-					cleanup(cleanupTask)
+					cleanup(task)
 					disconnect()
 
 				else
@@ -132,39 +78,33 @@ local function cleanupOnDestroy(instance: Instance?, cleanupTask: cleanup.Task):
 					-- out of event-based options.
 					while
 						isNilParented and
-						not isDisconnected and
-						(highTierConn.Connected and ignoreHighTierConn == false) and
-						ancestryChangedConn.Connected
+						ancestryChangedConn.Connected and
+						not isDisconnected
 					do
-
 						-- FUTURE: is this too often?
 						STEP_EVENT:Wait()
 					end
-					
+
 					-- The instance was either destroyed, or we stopped looping
 					-- for another reason (reparented or `disconnect` called)
 					-- Check those other conditions before calling the callback.
-					if
-						isDisconnected or
-						not isNilParented or
-						(ancestryChangedConn.Connected and (ignoreHighTierConn == true or (highTierConn.Connected and ignoreHighTierConn == false)))
-					then
+					if isDisconnected or not isNilParented then
 						return
 					end
 
-					cleanup(cleanupTask)
+					cleanup(task)
 					disconnect()
 				end
 			end)()
 		end
 	end
 
-	ancestryChangedConn = (instance :: Instance):GetPropertyChangedSignal("Parent"):Connect(onInstanceMove)
+	ancestryChangedConn = (instance :: Instance).AncestryChanged:Connect(onInstanceMove)
 
 	-- in case the instance is currently in nil, we should call `onInstanceMove`
 	-- before any other code has the opportunity to run
 	if isNilParented then
-		onInstanceMove(instance :: Instance, (instance :: Instance).Parent)
+		onInstanceMove(nil, (instance :: Instance).Parent)
 	end
 
 	-- remove this functions' reference to the instance, so it doesn't influence

--- a/src/Utility/cleanupOnDestroy_smart.lua
+++ b/src/Utility/cleanupOnDestroy_smart.lua
@@ -18,15 +18,24 @@ local cleanup = require(Package.Utility.cleanup)
 -- The event to use for waiting (typically Heartbeat)
 local STEP_EVENT = RunService.Heartbeat
 
-local function cleanupOnDestroy(instance: Instance?, task: cleanup.Task): (() -> ())
+local function noOp()
+	-- intentionally blank - no operation!
+end
+
+local function cleanupOnDestroy(instance: Instance?, cleanupTask: cleanup.Task): (() -> ())
 	-- set up manual disconnection logic
 	local isDisconnected = false
-	local ancestryChangedConn
+	local ancestryChangedConn, highTierConn
+	local ignoreHighTierConn = true
 
 	local function disconnect()
 		if not isDisconnected then
 			isDisconnected = true
 			ancestryChangedConn:Disconnect()
+
+			if highTierConn and highTierConn.Connected ~= nil then
+				highTierConn:Disconnect()
+			end
 		end
 	end
 
@@ -34,19 +43,64 @@ local function cleanupOnDestroy(instance: Instance?, task: cleanup.Task): (() ->
 	-- when the instance is parented to `nil`.
 	-- To get around this, we can save the parent from AncestryChanged here
 	local isNilParented = (instance :: Instance).Parent == nil
+	local parentTreeSize = 0
+
+	local function calculateFromTree(child: Instance)
+		parentTreeSize = 0
+
+		local finished = child == nil or child == game
+
+		if finished then
+			ignoreHighTierConn = true
+		else
+			while finished == false do
+				parentTreeSize += 1
+				local parent = child.Parent
+	
+				if parent == nil or parent == game then
+					if child then
+						if highTierConn then
+							highTierConn:Disconnect()
+						end
+	
+						highTierConn = child:GetPropertyChangedSignal("ClassName"):Connect(noOp)
+						ignoreHighTierConn = false
+	
+					else
+						ignoreHighTierConn = true
+					end
+					
+					finished = true
+				end
+	
+				child = parent
+			end
+		end
+
+		isNilParented = child == nil
+		child = nil
+	end
+	
+	calculateFromTree(instance :: Instance)
 
 	-- when AncestryChanged is called, run some destroy-checking logic
 	-- this function can yield when called, so make sure to call in a new thread
 	-- if you don't want your current thread to block
 	local function onInstanceMove(_doNotUse: Instance?, newParent: Instance?)
-		if isDisconnected then
-			return
-		end
+		local oldParentTreeSize = parentTreeSize
 
 		-- discard the first argument so we don't inhibit GC
-		_doNotUse = nil
+		if isDisconnected then
+			_doNotUse = nil
+			return
+			
+		else
+			-- determine how many objects there are until we reach `nil` or `game`
+			calculateFromTree(_doNotUse)
+			_doNotUse = nil
+		end
 
-		isNilParented = newParent == nil
+		--isNilParented = newParent == nil
 
 		-- if the instance has been moved into a nil parent, it could possibly
 		-- have been destroyed if no other references exist
@@ -64,7 +118,7 @@ local function cleanupOnDestroy(instance: Instance?, task: cleanup.Task): (() ->
 
 				elseif not ancestryChangedConn.Connected then
 					-- if our event was disconnected, the instance was destroyed
-					cleanup(task)
+					cleanup(cleanupTask)
 					disconnect()
 
 				else
@@ -78,33 +132,39 @@ local function cleanupOnDestroy(instance: Instance?, task: cleanup.Task): (() ->
 					-- out of event-based options.
 					while
 						isNilParented and
-						ancestryChangedConn.Connected and
-						not isDisconnected
+						not isDisconnected and
+						(highTierConn.Connected and ignoreHighTierConn == false) and
+						ancestryChangedConn.Connected
 					do
+
 						-- FUTURE: is this too often?
 						STEP_EVENT:Wait()
 					end
-
+					
 					-- The instance was either destroyed, or we stopped looping
 					-- for another reason (reparented or `disconnect` called)
 					-- Check those other conditions before calling the callback.
-					if isDisconnected or not isNilParented then
+					if
+						isDisconnected or
+						not isNilParented or
+						(ancestryChangedConn.Connected and (ignoreHighTierConn == true or (highTierConn.Connected and ignoreHighTierConn == false)))
+					then
 						return
 					end
 
-					cleanup(task)
+					cleanup(cleanupTask)
 					disconnect()
 				end
 			end)()
 		end
 	end
 
-	ancestryChangedConn = (instance :: Instance).AncestryChanged:Connect(onInstanceMove)
+	ancestryChangedConn = (instance :: Instance):GetPropertyChangedSignal("Parent"):Connect(onInstanceMove)
 
 	-- in case the instance is currently in nil, we should call `onInstanceMove`
 	-- before any other code has the opportunity to run
 	if isNilParented then
-		onInstanceMove(nil, (instance :: Instance).Parent)
+		onInstanceMove(instance :: Instance, (instance :: Instance).Parent)
 	end
 
 	-- remove this functions' reference to the instance, so it doesn't influence

--- a/src/Utility/cleanupOnDestroy_smart.lua
+++ b/src/Utility/cleanupOnDestroy_smart.lua
@@ -77,6 +77,9 @@ local function cleanupOnDestroy(instance: Instance?, cleanupTask: cleanup.Task):
 			end
 		end
 
+		if child == nil and not isNilParented and parentTreeSize > 0 then
+			print("Detected nil where it otherwise wouldn't")
+		end
 		isNilParented = child == nil
 		child = nil
 	end

--- a/test/Utility/cleanupOnDestroy.spec.lua
+++ b/test/Utility/cleanupOnDestroy.spec.lua
@@ -185,6 +185,37 @@ return function()
 		error("Instance was incorrectly collected")
 	end)
 
+	it("should not run tasks when parent is in nil, we hop to another parent in nil, and the first parent gets destroyed", function()
+		local parent1 = Instance.new("Folder")
+		local parent2 = Instance.new("Folder")
+		local ins = Instance.new("Folder")
+		ins.Parent = parent1
+
+		local done = false
+		local function callback()
+			done = true
+		end
+
+		cleanupOnDestroy(ins, callback)
+		
+		RunService.RenderStepped:Wait()
+		ins.Parent = parent2
+		RunService.RenderStepped:Wait()
+		parent1:Destroy()
+
+		local start = os.clock()
+		local timeout = 6
+
+		repeat
+			RunService.RenderStepped:Wait()
+			if os.clock() - start > timeout then
+				return
+			end
+		until done
+
+		error("Instance was incorrectly collected")
+	end)
+
 	it("should run tasks if parent is moved to nil then goes out of scope", function()
 		local done = false
 		local function callback()


### PR DESCRIPTION
"Successful" minimal polling version of ``cleanupOnDestroy_smart``. I'm really just putting this here so we can decide what to do.

**The good part:**
All the test cases now pass.

Speaking of test cases, I added 4 new test cases to directly examine this ancestry behavior and make sure there are no false positives. But I'm not sure I covered everything, and I can't think of more test cases. I'm looking for some other eyes to look over this (it's still in a draft phase), and help me come up with more test cases if necessary. 

I might also consider throwing the ``updateRefStrength()`` part of ``New.lua`` into ``cleanupTasks``.

**The bad part:**
This originally would crash benchmarking when throwing it under ``New.lua``. Dropping the benchmarking down to 1/10th of what it currently is lets the benchmarking run... But with the small issue that the game is literally unplayable as you get ~ 2 fps (I have a 2080 SUPER GPU)

Old benchmarking (cleanupOnDestroy):
```
[+] New
   [+] New with Children - array .................................................. 8.56 μs
   [+] New with Children - single ................................................. 9.90 μs
   [+] New with Children - state .................................................. 16.30 μs
   [+] New with OnChange .......................................................... 16.67 μs
   [+] New with OnEvent ........................................................... 14.53 μs
   [+] New with Parent - constant ................................................. 14.61 μs
   [+] New with Parent - state .................................................... 15.00 μs
   [+] New with properties - constant ............................................. 9.01 μs
   [+] New with properties - state ................................................ 16.72 μs
   [+] New without properties ..................................................... 5.13 μs
[+] Oklab
   [+] Convert from Oklab ......................................................... 0.27 μs
   [+] Convert to Oklab ........................................................... 0.35 μs
[+] Scheduler
   [+] Enqueue + run tasks - Single property, many instances, many priorities ..... 3.45 μs
   [+] Enqueue + run tasks - Single property, many instances, single priority ..... 3.55 μs
   [+] Enqueue + run tasks - Single property, single instance, single priority .... 1.23 μs
   [+] Enqueue callback to be called .............................................. 0.05 μs
   [+] Enqueue property change on instance ........................................ 0.06 μs
   [+] Run tasks - nothing queued ................................................. 0.03 μs
   [+] [1 call] Enqueue callback to be called ..................................... 0.30 μs
   [+] [1 call] Enqueue property change on instance ............................... 0.90 μs
[+] captureDependencies
   [+] Capture dependencies from callback ......................................... 0.13 μs
[+] updateAll
   [+] Update deep tree ........................................................... 2.06 μs
   [+] Update empty tree .......................................................... 0.33 μs
   [+] Update shallow tree ........................................................ 1.63 μs
   [+] Update tree with complex dependencies ...................................... 2.79 μs 
```

New benchmarking (cleanupOnDestroy_smart):
```
[+] New
   [+] New with Children - array .................................................. 7.67 μs
   [+] New with Children - single ................................................. 9.95 μs
   [+] New with Children - state .................................................. 14.92 μs
   [+] New with OnChange .......................................................... 17.76 μs
   [+] New with OnEvent ........................................................... 14.53 μs
   [+] New with Parent - constant ................................................. 14.54 μs
   [+] New with Parent - state .................................................... 15.99 μs
   [+] New with properties - constant ............................................. 8.78 μs
   [+] New with properties - state ................................................ 16.91 μs
   [+] New without properties ..................................................... 4.95 μs
[+] Oklab
   [+] Convert from Oklab ......................................................... 0.22 μs
   [+] Convert to Oklab ........................................................... 0.35 μs
[+] Scheduler
   [+] Enqueue + run tasks - Single property, many instances, many priorities ..... 3.32 μs
   [+] Enqueue + run tasks - Single property, many instances, single priority ..... 3.23 μs
   [+] Enqueue + run tasks - Single property, single instance, single priority .... 0.78 μs
   [+] Enqueue callback to be called .............................................. 0.04 μs
   [+] Enqueue property change on instance ........................................ 0.05 μs
   [+] Run tasks - nothing queued ................................................. 0.03 μs
   [+] [1 call] Enqueue callback to be called ..................................... 0.30 μs
   [+] [1 call] Enqueue property change on instance ............................... 0.60 μs
[+] captureDependencies
   [+] Capture dependencies from callback ......................................... 0.13 μs
[+] updateAll
   [+] Update deep tree ........................................................... 2.37 μs
   [+] Update empty tree .......................................................... 0.32 μs
   [+] Update shallow tree ........................................................ 2.01 μs
   [+] Update tree with complex dependencies ...................................... 3.04 μs
```