### PR TITLE
Add scriptable version information

### DIFF
--- a/src/PubTypes.lua
+++ b/src/PubTypes.lua
@@ -37,6 +37,12 @@ export type Animatable =
 	Vector3 |
 	Vector3int16
 
+-- Script-readable version information.
+export type Version = {
+	major: number,
+	minor: number,
+	isRelease: boolean
+}
 --[[
 	Generic reactive graph types
 ]]

--- a/src/init.lua
+++ b/src/init.lua
@@ -18,6 +18,8 @@ export type Tween<T> = PubTypes.Tween<T>
 export type Spring<T> = PubTypes.Spring<T>
 
 type Fusion = {
+	version = PubTypes.Version,
+
 	New: (className: string) -> ((propertyTable: PubTypes.PropertyTable) -> Instance),
 	Ref: PubTypes.RefKey,
 	Children: PubTypes.ChildrenKey,
@@ -34,6 +36,8 @@ type Fusion = {
 }
 
 return restrictRead("Fusion", {
+	version = {major = 0, minor = 2, isRelease = false},
+
 	New = require(script.Instances.New),
 	Ref = require(script.Instances.Ref),
 	Children = require(script.Instances.Children),

--- a/test/init.spec.lua
+++ b/test/init.spec.lua
@@ -6,6 +6,8 @@ return function()
 		expect(Fusion).to.be.a("table")
 
 		local api = {
+			version = "table",
+
 			New = "function",
 			Ref = "table",
 			Children = "table",


### PR DESCRIPTION
Pretty straightforward change - adding version information into the Fusion module itself should allow for any third-party libraries to do version checking pretty easily. Version information is accessible via `Fusion.version` as a table.

`major` and `minor` represent the first two numbers of Fusion's semver respectively - patch isn't included because these are typically only small non-consequential updates.

`isRelease` indicates whether this is a 'release' version of Fusion (i.e. identical to a version available on the Releases page) - this will be `false` if the library is pulled directly from GitHub, since these are typically working/'nightly' versions of the library.