### PR TITLE
add package.json so npm is supported

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "@elttob/fusion",
+    "version": "0.1.0",
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/elttob/Fusion.git"
+    },
+    "contributors": [
+        "elttob"
+    ],
+    "bugs": {
+        "url": "https://github.com/elttob/Fusion/issues"
+    }
+}


### PR DESCRIPTION
This allows the package to be installed via npm/git.
If you want to publish it to npm, you can run npm publish in command line to publish it.