### PR TITLE
Implement [Cleanup], take 2

### DIFF
--- a/src/Instances/Cleanup.lua
+++ b/src/Instances/Cleanup.lua
@@ -1,0 +1,20 @@
+--!strict
+
+--[[
+	A special key for property tables, which adds user-specified tasks to be run
+	when the instance is destroyed.
+]]
+
+local Package = script.Parent.Parent
+local PubTypes = require(Package.PubTypes)
+
+local Cleanup = {}
+Cleanup.type = "SpecialKey"
+Cleanup.kind = "Cleanup"
+Cleanup.stage = "observer"
+
+function Cleanup:apply(userTask: any, applyToRef: PubTypes.SemiWeakRef, cleanupTasks: {PubTypes.Task})
+	table.insert(cleanupTasks, userTask)
+end
+
+return Cleanup

--- a/src/init.lua
+++ b/src/init.lua
@@ -22,6 +22,7 @@ type Fusion = {
 
 	New: (className: string) -> ((propertyTable: PubTypes.PropertyTable) -> Instance),
 	Ref: PubTypes.SpecialKey,
+	Cleanup: PubTypes.SpecialKey,
 	Children: PubTypes.SpecialKey,
 	OnEvent: (eventName: string) -> PubTypes.SpecialKey,
 	OnChange: (propertyName: string) -> PubTypes.SpecialKey,
@@ -40,6 +41,7 @@ return restrictRead("Fusion", {
 
 	New = require(script.Instances.New),
 	Ref = require(script.Instances.Ref),
+	Cleanup = require(script.Instances.Cleanup),
 	Children = require(script.Instances.Children),
 	OnEvent = require(script.Instances.OnEvent),
 	OnChange = require(script.Instances.OnChange),

--- a/test/Instances/Cleanup.spec.lua
+++ b/test/Instances/Cleanup.spec.lua
@@ -12,6 +12,7 @@ return function()
 			[Cleanup] = instance
 		}
 		child:Destroy()
+		task.wait()
 
 		expect(conn.Connected).to.equal(false)
 	end)
@@ -24,6 +25,7 @@ return function()
 			[Cleanup] = conn
 		}
 		child:Destroy()
+		task.wait()
 
 		expect(conn.Connected).to.equal(false)
 	end)
@@ -37,6 +39,7 @@ return function()
 			end
 		}
 		child:Destroy()
+		task.wait()
 
 		expect(didRun).to.equal(true)
 	end)
@@ -52,6 +55,7 @@ return function()
 			}
 		}
 		child:Destroy()
+		task.wait()
 
 		expect(didRun).to.equal(true)
 	end)
@@ -67,6 +71,7 @@ return function()
 			}
 		}
 		child:Destroy()
+		task.wait()
 
 		expect(didRun).to.equal(true)
 	end)
@@ -79,11 +84,10 @@ return function()
 		end
 
 		local child = New "Folder" {
-			[Cleanup] = {
-				Destroy = {doRun, doRun, doRun}
-			}
+			[Cleanup] = {doRun, doRun, doRun}
 		}
 		child:Destroy()
+		task.wait()
 
 		expect(numRuns).to.equal(3)
 	end)
@@ -96,11 +100,10 @@ return function()
 		end
 
 		local child = New "Folder" {
-			[Cleanup] = {
-				Destroy = {{doRun, {doRun, {doRun}}}}
-			}
+			[Cleanup] = {{doRun, {doRun, {doRun}}}}
 		}
 		child:Destroy()
+		task.wait()
 
 		expect(numRuns).to.equal(3)
 	end)

--- a/test/Instances/Cleanup.spec.lua
+++ b/test/Instances/Cleanup.spec.lua
@@ -1,0 +1,122 @@
+local Package = game:GetService("ReplicatedStorage").Fusion
+local New = require(Package.Instances.New)
+local Cleanup = require(Package.Instances.Cleanup)
+
+return function()
+	it("should destroy instances", function()
+		local instance = New "Folder" {}
+		-- one of the only reliable ways to test for proper destruction
+		local conn = instance.AncestryChanged:Connect(function() end)
+
+		local child = New "Folder" {
+			[Cleanup] = instance
+		}
+		child:Destroy()
+
+		expect(conn.Connected).to.equal(false)
+	end)
+
+	it("should disconnect connections", function()
+		local instance = New "Folder" {}
+		local conn = instance.AncestryChanged:Connect(function() end)
+
+		local child = New "Folder" {
+			[Cleanup] = conn
+		}
+		child:Destroy()
+
+		expect(conn.Connected).to.equal(false)
+	end)
+
+	it("should invoke callbacks", function()
+		local didRun = false
+
+		local child = New "Folder" {
+			[Cleanup] = function()
+				didRun = true
+			end
+		}
+		child:Destroy()
+
+		expect(didRun).to.equal(true)
+	end)
+
+	it("should invoke :destroy() methods", function()
+		local didRun = false
+
+		local child = New "Folder" {
+			[Cleanup] = {
+				destroy = function()
+					didRun = true
+				end
+			}
+		}
+		child:Destroy()
+
+		expect(didRun).to.equal(true)
+	end)
+
+	it("should invoke :Destroy() methods", function()
+		local didRun = false
+
+		local child = New "Folder" {
+			[Cleanup] = {
+				Destroy = function()
+					didRun = true
+				end
+			}
+		}
+		child:Destroy()
+
+		expect(didRun).to.equal(true)
+	end)
+
+	it("should clean up contents of arrays", function()
+		local numRuns = 0
+
+		local function doRun()
+			numRuns += 1
+		end
+
+		local child = New "Folder" {
+			[Cleanup] = {
+				Destroy = {doRun, doRun, doRun}
+			}
+		}
+		child:Destroy()
+
+		expect(numRuns).to.equal(3)
+	end)
+
+	it("should clean up contents of nested arrays", function()
+		local numRuns = 0
+
+		local function doRun()
+			numRuns += 1
+		end
+
+		local child = New "Folder" {
+			[Cleanup] = {
+				Destroy = {{doRun, {doRun, {doRun}}}}
+			}
+		}
+		child:Destroy()
+
+		expect(numRuns).to.equal(3)
+	end)
+
+	it("should not inhibit garbage collection", function()
+		local ref = setmetatable({}, {__mode = "v"})
+		do
+			ref[1] = New "Folder" {
+				[Cleanup] = function() end
+			}
+		end
+
+		local startTime = os.clock()
+		repeat
+			task.wait()
+		until ref[1] == nil or os.clock() > startTime + 5
+		expect(ref[1]).to.equal(nil)
+	end)
+end

--- a/test/Utility/cleanup.spec.lua
+++ b/test/Utility/cleanup.spec.lua
@@ -1,0 +1,82 @@
+local Package = game:GetService("ReplicatedStorage").Fusion
+local New = require(Package.Instances.New)
+local cleanup = require(Package.Utility.cleanup)
+
+return function()
+	it("should destroy instances", function()
+		local instance = New "Folder" {}
+		-- one of the only reliable ways to test for proper destruction
+		local conn = instance.AncestryChanged:Connect(function() end)
+
+		cleanup(instance)
+
+		expect(conn.Connected).to.equal(false)
+	end)
+
+	it("should disconnect connections", function()
+		local instance = New "Folder" {}
+		local conn = instance.AncestryChanged:Connect(function() end)
+
+		cleanup(conn)
+
+		expect(conn.Connected).to.equal(false)
+	end)
+
+	it("should invoke callbacks", function()
+		local didRun = false
+
+		cleanup(function()
+			didRun = true
+		end)
+
+		expect(didRun).to.equal(true)
+	end)
+
+	it("should invoke :destroy() methods", function()
+		local didRun = false
+
+		cleanup({
+			destroy = function()
+				didRun = true
+			end
+		})
+
+		expect(didRun).to.equal(true)
+	end)
+
+	it("should invoke :Destroy() methods", function()
+		local didRun = false
+
+		cleanup({
+			Destroy = function()
+				didRun = true
+			end
+		})
+
+		expect(didRun).to.equal(true)
+	end)
+
+	it("should clean up contents of arrays", function()
+		local numRuns = 0
+
+		local function doRun()
+			numRuns += 1
+		end
+
+		cleanup({doRun, doRun, doRun})
+
+		expect(numRuns).to.equal(3)
+	end)
+
+	it("should clean up contents of nested arrays", function()
+		local numRuns = 0
+
+		local function doRun()
+			numRuns += 1
+		end
+
+		cleanup({{doRun, {doRun, {doRun}}}})
+
+		expect(numRuns).to.equal(3)
+	end)
+end

--- a/test/init.spec.lua
+++ b/test/init.spec.lua
@@ -10,6 +10,7 @@ return function()
 
 			New = "function",
 			Ref = "table",
+			Cleanup = "table",
 			Children = "table",
 			OnEvent = "function",
 			OnChange = "function",


### PR DESCRIPTION
Closes #26, and supersedes the previous pull request #104 from prior to the modular New rewrite.

There's not much to this, since most of the cleanup functionality is already handled internally and exposed to special keys via an API. It remains to be seen whether any actual unit tests are required here.