### PR TITLE
Code typo fixed

### DIFF
--- a/docs/tutorials/fundamentals/changing-children.md
+++ b/docs/tutorials/fundamentals/changing-children.md
@@ -43,7 +43,7 @@ local child3 = New "Folder" {}
 local children = State({child1, child2})
 
 local gui = New "TextLabel" {
-	[Children] = child
+	[Children] = children
 }
 
 children:set({child2, child3}) -- unparents child1, parents child2


### PR DESCRIPTION
It seems that the docs example was copied from the above snippet and the var name wasn't changed :P