### PR TITLE
fix: RepeatCount follows Roblox behaviour

### DIFF
--- a/src/Animation/Tween.lua
+++ b/src/Animation/Tween.lua
@@ -65,7 +65,8 @@ function class:update(): boolean
 	if tweenInfo.Reverses then
 		tweenDuration += tweenInfo.Time
 	end
-	tweenDuration *= tweenInfo.RepeatCount + 1
+	
+	tweenDuration *= math.sign(self._tweenInfo.RepeatCount + 1) + math.abs(self._tweenInfo.RepeatCount)
 	self._currentTweenDuration = tweenDuration
 
 	-- start animating this tween

--- a/src/Animation/TweenScheduler.lua
+++ b/src/Animation/TweenScheduler.lua
@@ -46,7 +46,7 @@ local function updateAllTweens()
 	for tween: Tween in pairs(allTweens :: any) do
 		local currentTime = now - tween._currentTweenStartTime
 
-		if currentTime > tween._currentTweenDuration then
+		if currentTime > tween._currentTweenDuration and tween._currentTweenInfo.RepeatCount > -1 then
 			if tween._currentTweenInfo.Reverses then
 				tween._currentValue = tween._prevValue
 			else

--- a/src/Animation/getTweenRatio.lua
+++ b/src/Animation/getTweenRatio.lua
@@ -11,7 +11,7 @@ local function getTweenRatio(tweenInfo: TweenInfo, currentTime: number): number
 	local delay = tweenInfo.DelayTime
 	local duration = tweenInfo.Time
 	local reverses = tweenInfo.Reverses
-	local numCycles = 1 + tweenInfo.RepeatCount
+	local numCycles = math.sign(tweenInfo.RepeatCount + 1) + math.abs(tweenInfo.RepeatCount) 
 	local easeStyle = tweenInfo.EasingStyle
 	local easeDirection = tweenInfo.EasingDirection
 
@@ -20,7 +20,7 @@ local function getTweenRatio(tweenInfo: TweenInfo, currentTime: number): number
 		cycleDuration += duration
 	end
 
-	if currentTime >= cycleDuration * numCycles then
+	if currentTime >= cycleDuration * numCycles and tweenInfo.RepeatCount > -1 then
 		return 1
 	end
 

--- a/src/Animation/getTweenRatio.lua
+++ b/src/Animation/getTweenRatio.lua
@@ -11,7 +11,7 @@ local function getTweenRatio(tweenInfo: TweenInfo, currentTime: number): number
 	local delay = tweenInfo.DelayTime
 	local duration = tweenInfo.Time
 	local reverses = tweenInfo.Reverses
-	local numCycles = math.sign(tweenInfo.RepeatCount + 1) + math.abs(tweenInfo.RepeatCount) 
+	local numCycles = 1 + tweenInfo.RepeatCount
 	local easeStyle = tweenInfo.EasingStyle
 	local easeDirection = tweenInfo.EasingDirection
 


### PR DESCRIPTION
This is my suggested solution for issue #172 

This pull request resolves this issue by adding one to the RepeatCount and using `math.sign` to get the signed result
this means that:
0 will be 1
and
-1 will be 0

I then add the absolute value of the RepeatCount onto this number, meaning 
0 which was 1 will become 1
-1 which was 0 will become 1

This correctly creates the RepeatCount whilst ensuring that edge cases such as negative numbers or zero are resolved, to try to conform to the Roblox behaviour.

In order to accomplish the looping behaviour I ensure tweens that have a RepeatCount of -1 will always update their tween again by adjusting the if statement as so:
`if currentTime > tween._currentTweenDuration and tween._currentTweenInfo.RepeatCount > -1 then`