### PR TITLE
Add default properties for CanvasGroup

### DIFF
--- a/src/Instances/defaultProps.lua
+++ b/src/Instances/defaultProps.lua
@@ -99,5 +99,11 @@ return {
 		BackgroundColor3 = Color3.new(1, 1, 1),
 		BorderColor3 = Color3.new(0, 0, 0),
 		BorderSizePixel = 0
+	},
+	
+	CanvasGroup = {
+		BackgroundColor3 = Color3.new(1, 1, 1),
+		BorderColor3 = Color3.new(0, 0, 0),
+		BorderSizePixel = 0
 	}
 }


### PR DESCRIPTION
[CanvasGroup](https://devforum.roblox.com/t/canvasgroup-beta-group-transparency-on-ui-groups/1797885) is a beta object recently introduced by Roblox.

This pull request seeks to add the default properties commonly added to new objects to CanvasGroup.