### PR TITLE
For-xyz rewrite

### DIFF
--- a/src/State/ForKeys.lua
+++ b/src/State/ForKeys.lua
@@ -1,14 +1,14 @@
 --!nonstrict
 
 --[[
-	Constructs a new ForKeys state object which maps keys of a table using
+	Constructs a new ForKeys state object which maps keys of an array using
 	a `processor` function.
 
-	Optionally, a `destructor` function can be specified for cleaning up values.
-	If omitted, the default cleanup function will be used instead.
+	Optionally, a `destructor` function can be specified for cleaning up
+	calculated keys. If omitted, the default cleanup function will be used instead.
 
-    Additionally, a `meta` table/value can optionally be returned to pass data created
-    when running the processor to the destructor when the created object is cleaned up.
+	Optionally, a `meta` value can be returned in the processor function as the
+	second value to pass data from the processor to the destructor.
 ]]
 
 local Package = script.Parent.Parent
@@ -27,13 +27,18 @@ local class = {}
 local CLASS_METATABLE = { __index = class }
 local WEAK_KEYS_METATABLE = { __mode = "k" }
 
+
+--[[
+	Default cleanup function that gets used as the destructor if no function is
+	provided by the user.
+]]
 local function forKeysCleanup(keyOut: any, meta: any?)
 	cleanup(keyOut)
-
 	if meta then
 		cleanup(meta)
 	end
 end
+
 
 --[[
 	Returns the current value of this ForKeys object.
@@ -46,57 +51,60 @@ function class:get(asDependency: boolean?): any
 	return self._outputTable
 end
 
+
 --[[
 	Called when the original table is changed.
 
 	This will firstly find any keys meeting any of the following criteria:
 
 	- they were not previously present
-	- a dependency used during generation of this key has changed
+	- a dependency used during generation of this value has changed
 
-	It will recalculate those keys, storing information about any dependencies used
-	in the processor callback during value generation, and saving the new key to the
-	output array with the same value. If it is overwriting an older value, that older
-	value will be passed to the destructor for cleanup.
+	It will recalculate those key pairs, storing information about any
+	dependencies used in the processor callback during output key generation,
+	and save the new key to the output array with the same value. If it is
+	overwriting an older value, that older value will be passed to the
+	destructor for cleanup.
 
 	Finally, this function will find keys that are no longer present, and remove
-	their output key from the output table and pass them to the destructor.
+	their output keys from the output table and pass them to the destructor.
 ]]
+
 function class:update(): boolean
 	local inputIsState = self._inputIsState
-	local oldInputKeys = self._oldInputTable
-	local newInputKeys = self._inputTable
+	local newInputTable = if inputIsState then self._inputTable:get(false) else self._inputTable
+	local oldInputTable = self._oldInputTable
+	local outputTable = self._outputTable
+
 	local keyOIMap = self._keyOIMap
-	local outputKeys = self._outputTable
+	local keyIOMap = self._keyIOMap
 	local meta = self._meta
 
-	if inputIsState then
-		newInputKeys = newInputKeys:get(false)
-	end
-
 	local didChange = false
+
 
 	-- clean out main dependency set
 	for dependency in pairs(self.dependencySet) do
 		dependency.dependentSet[self] = nil
 	end
+
 	self._oldDependencySet, self.dependencySet = self.dependencySet, self._oldDependencySet
 	table.clear(self.dependencySet)
 
-	-- if the input table is a state object, add as dependency
+	-- if the input table is a state object, add it as a dependency
 	if inputIsState then
 		self._inputTable.dependentSet[self] = true
 		self.dependencySet[self._inputTable] = true
 	end
 
-	-- STEP 1: find keys that were not previously present
-	for newInKey, _value in pairs(newInputKeys) do
+
+	-- STEP 1: find keys that changed or were not previously present
+	for newInKey, value in pairs(newInputTable) do
 		-- get or create key data
 		local keyData = self._keyData[newInKey]
+
 		if keyData == nil then
 			keyData = {
-				-- we don't need strong references here - the main set does that
-				-- for us, so let's not introduce unnecessary leak opportunities
 				dependencySet = setmetatable({}, WEAK_KEYS_METATABLE),
 				oldDependencySet = setmetatable({}, WEAK_KEYS_METATABLE),
 				dependencyValues = setmetatable({}, WEAK_KEYS_METATABLE),
@@ -104,16 +112,12 @@ function class:update(): boolean
 			self._keyData[newInKey] = keyData
 		end
 
-		-- if an input key's previous value is non-nil, then there's no need to recalculate it
-		-- this also allows it to have a non-truthy value, which is important since we don't care
-		-- about the value; if we have dependencies then we also need to check if they've changed,
-		-- since if they have then the key has "changed".
-		local shouldRecalculate = oldInputKeys[newInKey] == nil
+		-- check if the key is new
+		local shouldRecalculate = oldInputTable[newInKey] == nil
 
-		if not shouldRecalculate then
-			-- check if dependencies have changed
+		-- check if the key's dependencies have changed
+		if shouldRecalculate == false then
 			for dependency, oldValue in pairs(keyData.dependencyValues) do
-				-- if the dependency changed value, then this needs recalculating
 				if oldValue ~= dependency:get(false) then
 					shouldRecalculate = true
 					break
@@ -121,7 +125,8 @@ function class:update(): boolean
 			end
 		end
 
-		-- if we should recalculate the output by this point, do that
+
+		-- recalculate the output key if necessary
 		if shouldRecalculate then
 			keyData.oldDependencySet, keyData.dependencySet = keyData.dependencySet, keyData.oldDependencySet
 			table.clear(keyData.dependencySet)
@@ -134,20 +139,34 @@ function class:update(): boolean
 
 			if processOK then
 				local oldInKey = keyOIMap[newOutKey]
+				local oldOutKey = keyIOMap[newInKey]
 
-				-- if there are colliding output keys, throw an error
-				if oldInKey ~= newInKey and newInputKeys[oldInKey] ~= nil then
+				-- check for key collision
+				if oldInKey ~= newInKey and newInputTable[oldInKey] ~= nil then
 					logError("forKeysKeyCollision", nil, tostring(newOutKey), tostring(oldInKey), tostring(newOutKey))
 				end
 
-				-- make the old input match the new input value
-				oldInputKeys[newInKey] = _value
-				-- store the new meta value in the table
+				-- check for a changed output key
+				if oldOutKey ~= newOutKey and keyOIMap[oldOutKey] == newInKey then
+					-- clean up the old calculated value
+					local oldMetaValue = meta[oldOutKey]
+
+					local destructOK, err = xpcall(self._destructor, parseError, oldOutKey, oldMetaValue)
+					if not destructOK then
+						logErrorNonFatal("forKeysDestructorError", err)
+					end
+
+					keyOIMap[oldOutKey] = nil
+					outputTable[oldOutKey] = nil
+					meta[oldOutKey] = nil
+				end
+
+				-- update the stored data for this key
+				oldInputTable[newInKey] = value
 				meta[newOutKey] = newMetaValue
-				-- store the new output key for next time we run the output comparison
 				keyOIMap[newOutKey] = newInKey
-				-- store the new output key in the table with its original value, which we give to the user
-				outputKeys[newOutKey] = _value
+				keyIOMap[newInKey] = newOutKey
+				outputTable[newOutKey] = value
 
 				-- if we had to recalculate the output, then we did change
 				didChange = true
@@ -158,13 +177,21 @@ function class:update(): boolean
 				logErrorNonFatal("forKeysProcessorError", newOutKey)
 			end
 		end
+
+
+		-- save dependency values and add to main dependency set
+		for dependency in pairs(keyData.dependencySet) do
+			keyData.dependencyValues[dependency] = dependency:get(false)
+
+			self.dependencySet[dependency] = true
+			dependency.dependentSet[self] = true
+		end
 	end
 
-	-- STEP 2: find keys that were removed
 
+	-- STEP 2: find keys that were removed
 	for outputKey, inputKey in pairs(keyOIMap) do
-		-- if the output key doesn't have an equivalent input key in the new input table
-		if newInputKeys[inputKey] == nil then
+		if newInputTable[inputKey] == nil then
 			-- clean up the old calculated value
 			local oldMetaValue = meta[outputKey]
 
@@ -173,15 +200,12 @@ function class:update(): boolean
 				logErrorNonFatal("forKeysDestructorError", err)
 			end
 
-			-- remove input key
-			oldInputKeys[inputKey] = nil
-			-- remove meta data
+			-- remove data
+			oldInputTable[inputKey] = nil
 			meta[outputKey] = nil
-			-- remove key OI data
 			keyOIMap[outputKey] = nil
-			-- remove output key
-			outputKeys[outputKey] = nil
-			-- remove key data
+			keyIOMap[inputKey] = nil
+			outputTable[outputKey] = nil
 			self._keyData[inputKey] = nil
 
 			-- if we removed a key, then the table/state changed
@@ -221,6 +245,7 @@ local function ForKeys<KI, KO, M>(
 		_oldInputTable = {},
 		_outputTable = {},
 		_keyOIMap = {},
+		_keyIOMap = {},
 		_keyData = {},
 		_meta = {},
 	}, CLASS_METATABLE)

--- a/src/State/ForValues.lua
+++ b/src/State/ForValues.lua
@@ -1,16 +1,15 @@
 --!nonstrict
 
 --[[
-	Constructs a new ForValues state object which maps values of a table using
+	Constructs a new ForValues object which maps values of a table using
 	a `processor` function.
 
 	Optionally, a `destructor` function can be specified for cleaning up values.
 	If omitted, the default cleanup function will be used instead.
 
-    Additionally, a `meta` table/value can optionally be returned to pass data created
-    when running the processor to the destructor when the created object is cleaned up.
+	Additionally, a `meta` table/value can optionally be returned to pass data created
+	when running the processor to the destructor when the created object is cleaned up.
 ]]
-
 local Package = script.Parent.Parent
 local PubTypes = require(Package.PubTypes)
 local Types = require(Package.Types)
@@ -54,29 +53,27 @@ end
 	- a dependency used during generation of this value has changed
 
 	It will recalculate those values, storing information about any dependencies
-    used in the processor callback during value generation, and save the new value
-    to the output array with the same key. If it is overwriting an older value,
+	used in the processor callback during value generation, and save the new value
+	to the output array with the same key. If it is overwriting an older value,
 	that older value will be passed to the destructor for cleanup.
 
 	Finally, this function will find values that are no longer present, and remove
 	their values from the output table and pass them to the destructor. You can re-use
-    the same value multiple times and this will function will update them as little as
-    possible; reusing the same values where possible.
+	the same value multiple times and this will function will update them as little as
+	possible; reusing the same values where possible.
 ]]
 function class:update(): boolean
 	local inputIsState = self._inputIsState
-	local inputValues = self._inputTable
-	local newValueCache = self._oldValueCache -- _oldValueCache and _valueCache get swapped and cleared below
-	local oldValueCache = self._valueCache
-	local dependenciesCaptured = {} -- we use this to cache dependency checks/captures
+	local inputTable = if inputIsState then self._inputTable:get(false) else self._inputTable
 	local outputValues = {}
-	local meta = self._meta
-
-	if inputIsState then
-		inputValues = inputValues:get(false)
-	end
 
 	local didChange = false
+
+	-- clean out value cache
+	self._oldValueCache, self._valueCache = self._valueCache, self._oldValueCache
+	local newValueCache = self._valueCache
+	local oldValueCache = self._oldValueCache
+	table.clear(newValueCache)
 
 	-- clean out main dependency set
 	for dependency in pairs(self.dependencySet) do
@@ -85,197 +82,129 @@ function class:update(): boolean
 	self._oldDependencySet, self.dependencySet = self.dependencySet, self._oldDependencySet
 	table.clear(self.dependencySet)
 
-	-- swap caches and clear out the old value cache
-	self._oldValueCache, self._valueCache = oldValueCache, newValueCache
-	table.clear(newValueCache)
-
-	-- if the input table is a state object, add as dependency
+	-- if the input table is a state object, add it as a dependency
 	if inputIsState then
 		self._inputTable.dependentSet[self] = true
 		self.dependencySet[self._inputTable] = true
 	end
 
-	-- STEP 1: find values that changed or were not previously present
-	for _key, inValue in pairs(inputValues) do
-		local cachedValue = oldValueCache[inValue]
-		local newCachedValue = newValueCache[inValue]
-		local shouldRecalculate = cachedValue == nil
 
-		-- get value data
-		local valueData = self._valueData[inValue]
+	-- STEP 1: find values that changed or were not previously present
+	for inKey, inValue in pairs(inputTable) do
+		-- check if the value is new or changed
+		local oldCachedValues = oldValueCache[inValue]
+		local shouldRecalculate = oldCachedValues == nil
+
+		-- get a cached value and its dependency/meta data if available
+		local value, valueData, meta
+
+		if type(oldCachedValues) == "table" and #oldCachedValues > 0 then
+			local valueInfo = table.remove(oldCachedValues, #oldCachedValues)
+			value = valueInfo.value
+			valueData = valueInfo.valueData
+			meta = valueInfo.meta
+
+			if #oldCachedValues <= 0 then
+				oldValueCache[inValue] = nil
+			end
+		elseif oldCachedValues ~= nil then
+			oldValueCache[inValue] = nil
+			shouldRecalculate = true
+		end
+
 		if valueData == nil then
 			valueData = {
-				-- we don't need strong references here - the main set does that
-				-- for us, so let's not introduce unnecessary leak opportunities
 				dependencySet = setmetatable({}, WEAK_KEYS_METATABLE),
 				oldDependencySet = setmetatable({}, WEAK_KEYS_METATABLE),
 				dependencyValues = setmetatable({}, WEAK_KEYS_METATABLE),
 			}
-			self._valueData[inValue] = valueData
 		end
 
-		-- if we already cached a new constant (non-table) value on this run-through,
-		-- then we can just re-use that as the cached value
-		if newCachedValue ~= nil and type(newCachedValue) ~= "table" then
-			cachedValue = newCachedValue
-			shouldRecalculate = false
-
-			-- check inputValue dependencies if we have a cached value
-			-- if we don't have a cached value, then there's no point in checking dependencies
-			-- we also verify that we haven't already captured the dependencies for this inValue
-			-- since if we have, then we don't need to recalculate and can skip this step
-		elseif not shouldRecalculate and dependenciesCaptured[inValue] == nil then
-			-- check if dependencies have changed
+		-- check if the value's dependencies have changed
+		if shouldRecalculate == false then
 			for dependency, oldValue in pairs(valueData.dependencyValues) do
-				-- if the dependency changed value, then this needs recalculating
 				if oldValue ~= dependency:get(false) then
 					shouldRecalculate = true
 					break
 				end
 			end
+		end
 
-			--[[
-                If the dependencies have changed then:
-                    1: clean up cached value(s), because they are no longer any good
-                    2: Swap the old/new dependencies
+		-- recalculate the output value if necessary
+		if shouldRecalculate then
+			valueData.oldDependencySet, valueData.dependencySet = valueData.dependencySet, valueData.oldDependencySet
+			table.clear(valueData.dependencySet)
 
-                This also makes the cached value 'nil', which fits
-            ]]
-			if shouldRecalculate then
-				-- step 1: clean up cached value(s), because they are no longer any good
-				-- this also tells future runs to calculate a fresh output value
-				cachedValue = if type(cachedValue) == "table" then cachedValue else {cachedValue}
+			local processOK, newOutValue, newMetaValue = captureDependencies(
+				valueData.dependencySet,
+				self._processor,
+				inValue
+			)
 
-				for _, outputValue in ipairs(cachedValue) do
-					-- clean up the old calculated value
-					local oldMetaValue = meta[outputValue]
-					local destructOK, err = xpcall(self._destructor, parseError, outputValue, oldMetaValue)
+			if processOK then
+				-- pass the old value to the destructor if it exists
+				if value ~= nil then
+					local destructOK, err = xpcall(self._destructor, parseError, value, meta)
 					if not destructOK then
 						logErrorNonFatal("forValuesDestructorError", err)
 					end
-
-					-- remove stored value data
-					meta[outputValue] = nil
 				end
 
-				-- step 2: swap the old/new dependencies; clean out the new dependency set so we get a fresh start
-				valueData.oldDependencySet, valueData.dependencySet =
-					valueData.dependencySet, valueData.oldDependencySet
-				table.clear(valueData.dependencySet)
-
-				-- step 3: remove stored cached value
-				oldValueCache[inValue] = nil
-				cachedValue = nil
-			else
-				-- inform future runs that we already checked this inValue's dependencies,
-				-- and that we don't need to re-capture dependencies
-				dependenciesCaptured[inValue] = true
-			end
-		end
-
-		-- if we still don't need to recalculate, then we can re-use a cached value
-		-- if there are no cached values, then set recalculate to true and
-		-- calculate a new value
-		if not shouldRecalculate then
-			-- if we're using a table, then try to pull a value from the cache
-			if type(cachedValue) == "table" then
-				local cachedValues = cachedValue
-				local cachedValuesSize = #cachedValues
-
-				if cachedValuesSize > 0 then
-					cachedValue = cachedValues[cachedValuesSize]
-					table.remove(cachedValues, cachedValuesSize)
-				else
-					cachedValue = nil
-					shouldRecalculate = true
-				end
-			end
-		end
-
-		-- if we should recalculate the output by this point, do that
-		if shouldRecalculate then
-			local processOK, newOutValue, newMetaValue
-
-			-- if we already captured the dependencies for this inValue, we don't need to do it again
-			if dependenciesCaptured[inValue] then
-				processOK, newOutValue, newMetaValue = pcall(self._processor, inValue)
-
-				-- otherwise, we need to capture the dependencies
-			else
-				processOK, newOutValue, newMetaValue = captureDependencies(
-					valueData.dependencySet,
-					self._processor,
-					inValue
-				)
-			end
-
-			if processOK then
-				-- prepare the value to be cached
-				cachedValue = newOutValue
-				-- store meta value, since we don't touch that when reusing values
-				meta[newOutValue] = newMetaValue
-				-- inform future runs that we already captured the dependencies
-				dependenciesCaptured[inValue] = true
-
+				-- store the new value and meta data
+				value = newOutValue
+				meta = newMetaValue
 				didChange = true
 			else
+				-- restore old dependencies, because the new dependencies may be corrupt
+				valueData.oldDependencySet, valueData.dependencySet = valueData.dependencySet, valueData.oldDependencySet
+
 				logErrorNonFatal("forValuesProcessorError", newOutValue)
 			end
 		end
 
-		-- if we successfully created a new value or found a value to reuse,
-		-- cache it and update the stored data
-		if cachedValue ~= nil then
-			-- we store tables and objects in an array of cached objects, since they need to be unique
-			if type(cachedValue) == "userdata" or type(cachedValue) == "table" then
-				local cachedValues = newValueCache[inValue]
-				if not cachedValues then
-					cachedValues = {}
-					newValueCache[inValue] = cachedValues
-				end
 
-				table.insert(cachedValues, cachedValue)
-			else
-				newValueCache[inValue] = cachedValue
-			end
+		-- store the value and its dependency/meta data
+		local newCachedValues = newValueCache[inValue]
+		if newCachedValues == nil then
+			newCachedValues = {}
+			newValueCache[inValue] = newCachedValues
+		end
 
-			-- store the value in the output with the same key
-			outputValues[_key] = cachedValue
+		table.insert(newCachedValues, {
+			value = value,
+			valueData = valueData,
+			meta = meta,
+		})
+
+		outputValues[inKey] = value
+
+
+		-- save dependency values and add to main dependency set
+		for dependency in pairs(valueData.dependencySet) do
+			valueData.dependencyValues[dependency] = dependency:get(false)
+
+			self.dependencySet[dependency] = true
+			dependency.dependentSet[self] = true
 		end
 	end
 
+
 	-- STEP 2: find values that were removed
 	-- for tables of data, we just need to check if it's still in the cache
-	for oldInValue, oldCachedValue in pairs(oldValueCache) do
-		if type(oldCachedValue) == "table" then
-			-- clean up any remaining cached values
-			for _, cachedValue in ipairs(oldCachedValue) do
-				local oldMetaValue = meta[cachedValue]
-				local destructOK, err = xpcall(self._destructor, parseError, cachedValue, oldMetaValue)
-				if not destructOK then
-					logErrorNonFatal("forValuesDestructorError", err)
-				end
+	for _oldInValue, oldCachedValueInfo in pairs(oldValueCache) do
+		for _, valueInfo in ipairs(oldCachedValueInfo) do
+			local oldValue = valueInfo.value
+			local oldMetaValue = valueInfo.meta
 
-				-- remove stored value data
-				meta[cachedValue] = nil
-
-				-- if we removed a value, then we did change
-				didChange = true
-			end
-		elseif newValueCache[oldInValue] ~= oldCachedValue then
-			-- clean up the old calculated value
-			local oldMetaValue = meta[oldCachedValue]
-			local destructOK, err = xpcall(self._destructor, parseError, oldCachedValue, oldMetaValue)
+			local destructOK, err = xpcall(self._destructor, parseError, oldValue, oldMetaValue)
 			if not destructOK then
 				logErrorNonFatal("forValuesDestructorError", err)
 			end
 
-			-- remove stored value data
-			meta[oldCachedValue] = nil
-
-			-- if we removed a value, then we did change
 			didChange = true
 		end
+
+		table.clear(oldCachedValueInfo)
 	end
 
 	self._outputTable = outputValues
@@ -312,8 +241,6 @@ local function ForValues<VI, VO, M>(
 		_outputTable = {},
 		_valueCache = {},
 		_oldValueCache = {},
-		_valueData = {},
-		_meta = {},
 	}, CLASS_METATABLE)
 
 	initDependency(self)

--- a/src/Types.lua
+++ b/src/Types.lua
@@ -77,6 +77,7 @@ export type ForKeys<KI, KO, M> = PubTypes.ForKeys<KO, any> & {
 	_oldInputTable: { [KI]: KO },
 	_outputTable: { [KO]: any },
 	_keyOIMap: { [KO]: KI },
+	_keyIOMap: { [KI]: KO },
 	_meta: { [KO]: M? },
 	_keyData: {
 		[KI]: {
@@ -88,6 +89,16 @@ export type ForKeys<KI, KO, M> = PubTypes.ForKeys<KO, any> & {
 }
 
 -- A state object whose value is derived from other objects using a callback.
+export type ForValuesValueInfo<VO, M> = {
+	value: VO,
+	meta: M?,
+	valueData: {
+		dependencySet: Set<PubTypes.Dependency>,
+		oldDependencySet: Set<PubTypes.Dependency>,
+		dependencyValues: { [PubTypes.Dependency]: any },
+	}
+}
+
 export type ForValues<VI, VO, M> = PubTypes.ForValues<any, VO> & {
 	_oldDependencySet: Set<PubTypes.Dependency>,
 	_processor: (VI) -> (VO),
@@ -95,16 +106,9 @@ export type ForValues<VI, VO, M> = PubTypes.ForValues<any, VO> & {
 	_inputIsState: boolean,
 	_inputTable: PubTypes.CanBeState<{ [VI]: VO }>,
 	_outputTable: { [any]: VI },
-	_valueCache: { [VO]: any },
-	_oldValueCache: { [VO]: any },
+	_valueCache: { [VI]: { ForValuesValueInfo<VO, M> } },
+	_oldValueCache: { [VI]: { ForValuesValueInfo<VO, M> } },
 	_meta: { [VO]: M? },
-	_valueData: {
-		[VI]: {
-			dependencySet: Set<PubTypes.Dependency>,
-			oldDependencySet: Set<PubTypes.Dependency>,
-			dependencyValues: { [PubTypes.Dependency]: any },
-		},
-	},
 }
 
 -- A state object which follows another state object using tweens.

--- a/test/State/ForKeys.spec.lua
+++ b/test/State/ForKeys.spec.lua
@@ -230,6 +230,53 @@ return function()
 		expect(computedBarBiz:get()["bazbarbiz"]).to.be.ok()
 	end)
 
+	it("should recalculate its value in response to a dependency change", function()
+		local state = Value({ 
+			[1] = true,
+			[5] = true,
+			[10] = true,
+		 })
+		local increment = Value(1)
+
+		local computed = ForKeys(state, function(key)
+			return key + increment:get()
+		end)
+
+		expect(computed:get()[1]).never.to.be.ok()
+		expect(computed:get()[5]).never.to.be.ok()
+		expect(computed:get()[10]).never.to.be.ok()
+
+		expect(computed:get()[2]).to.be.ok()
+		expect(computed:get()[6]).to.be.ok()
+		expect(computed:get()[11]).to.be.ok()
+
+		increment:set(2)
+
+		task.wait()
+		task.wait()
+
+		expect(computed:get()[2]).never.to.be.ok()
+		expect(computed:get()[6]).never.to.be.ok()
+		expect(computed:get()[11]).never.to.be.ok()
+
+		expect(computed:get()[3]).to.be.ok()
+		expect(computed:get()[7]).to.be.ok()
+		expect(computed:get()[12]).to.be.ok()
+
+		increment:set(1)
+
+		task.wait()
+		task.wait()
+
+		expect(computed:get()[3]).never.to.be.ok()
+		expect(computed:get()[7]).never.to.be.ok()
+		expect(computed:get()[12]).never.to.be.ok()
+
+		expect(computed:get()[2]).to.be.ok()
+		expect(computed:get()[6]).to.be.ok()
+		expect(computed:get()[11]).to.be.ok()
+	end)
+
 	it("should not corrupt dependencies after an error", function()
 		local state = Value({
 			["foo"] = "bar",

--- a/test/State/ForKeys.spec.lua
+++ b/test/State/ForKeys.spec.lua
@@ -14,22 +14,22 @@ end
 
 return function()
 	it("should construct a ForKeys object", function()
-		local forKeys = ForKeys({}, function() end)
+		local state = ForKeys({}, function() end)
 
-		expect(forKeys).to.be.a("table")
-		expect(forKeys.type).to.equal("State")
-		expect(forKeys.kind).to.equal("ForKeys")
+		expect(state).to.be.a("table")
+		expect(state.type).to.equal("State")
+		expect(state.kind).to.equal("ForKeys")
 	end)
 
 	it("should calculate and retrieve its value", function()
-		local computedPair = ForKeys({ ["foo"] = true }, function(key)
+		local state = ForKeys({ ["foo"] = true }, function(key)
 			return key .. "baz"
 		end)
 
-		local state = computedPair:get()
+		local value = state:get()
 
-		expect(state["foobaz"]).to.be.ok()
-		expect(state["foobaz"]).to.equal(true)
+		expect(value["foobaz"]).to.be.ok()
+		expect(value["foobaz"]).to.equal(true)
 	end)
 
 	it("should not recalculate its KO in response to an unchanged KI", function()
@@ -39,7 +39,7 @@ return function()
 
 		local calculations = 0
 
-		local computedPair = ForKeys(state, function(key)
+		local _computed = ForKeys(state, function(key)
 			calculations += 1
 			return key
 		end)
@@ -62,9 +62,9 @@ return function()
 
 		local destructions = 0
 
-		local computedPair = ForKeys(state, function(key)
+		local _computed = ForKeys(state, function(key)
 			return key .. "biz"
-		end, function(key)
+		end, function()
 			destructions += 1
 		end)
 
@@ -99,7 +99,7 @@ return function()
 				["baz"] = "bar",
 			})
 
-			local computed = ForKeys(state, function()
+			local _computed = ForKeys(state, function()
 				return "foo"
 			end)
 		end).to.throw("forKeysKeyCollision")
@@ -108,7 +108,7 @@ return function()
 			["foo"] = "bar",
 		})
 
-		local computed = ForKeys(state, function()
+		local _computed = ForKeys(state, function()
 			return "foo"
 		end)
 
@@ -127,7 +127,7 @@ return function()
 
 		local destructions = 0
 
-		local computedKey = ForKeys(state, function(key)
+		local _computed = ForKeys(state, function(key)
 			local newKey = key .. "biz"
 			return newKey, newKey
 		end, function(key, meta)
@@ -161,7 +161,7 @@ return function()
 
 		local destructions = 0
 
-		local computedKey = ForKeys(state, function(key)
+		local _computed = ForKeys(state, function(key)
 			return map[key]
 		end, function()
 			destructions += 1
@@ -189,45 +189,45 @@ return function()
 	end)
 
 	it("should recalculate its value in response to State objects", function()
-		local baseMap = Value({
+		local state = Value({
 			["foo"] = "baz",
 		})
-		local barMap = ForKeys(baseMap, function(key)
+		local computedBar = ForKeys(state, function(key)
 			return key .. "bar"
 		end)
 
-		expect(barMap:get()["foobar"]).to.be.ok()
+		expect(computedBar:get()["foobar"]).to.be.ok()
 
-		baseMap:set({
+		state:set({
 			["baz"] = "foo",
 		})
 
-		expect(barMap:get()["bazbar"]).to.be.ok()
+		expect(computedBar:get()["bazbar"]).to.be.ok()
 	end)
 
 	it("should recalculate its value in response to ForKeys objects", function()
-		local baseMap = Value({
+		local map = Value({
 			["foo"] = "baz",
 		})
-		local barMap = ForKeys(baseMap, function(key)
+		local computedBar = ForKeys(map, function(key)
 			return key .. "bar"
 		end)
-		local bizMap = ForKeys(barMap, function(key)
+		local computedBarBiz = ForKeys(computedBar, function(key)
 			return key .. "biz"
 		end)
 
-		expect(barMap:get()["foobar"]).to.be.ok()
-		expect(bizMap:get()["foobarbiz"]).to.be.ok()
+		expect(computedBar:get()["foobar"]).to.be.ok()
+		expect(computedBarBiz:get()["foobarbiz"]).to.be.ok()
 
-		baseMap:set({
+		map:set({
 			["fiz"] = "foo",
 			["baz"] = "foo",
 		})
 
-		expect(barMap:get()["fizbar"]).to.be.ok()
-		expect(bizMap:get()["fizbarbiz"]).to.be.ok()
-		expect(barMap:get()["bazbar"]).to.be.ok()
-		expect(bizMap:get()["bazbarbiz"]).to.be.ok()
+		expect(computedBar:get()["fizbar"]).to.be.ok()
+		expect(computedBarBiz:get()["fizbarbiz"]).to.be.ok()
+		expect(computedBar:get()["bazbar"]).to.be.ok()
+		expect(computedBarBiz:get()["bazbarbiz"]).to.be.ok()
 	end)
 
 	it("should not corrupt dependencies after an error", function()
@@ -271,7 +271,7 @@ return function()
 		local counter = 0
 
 		do
-			local computedKeys = ForKeys(state, function(key)
+			local _computed = ForKeys(state, function(key)
 				counter += 1
 				return key
 			end)

--- a/test/State/ForPairs.spec.lua
+++ b/test/State/ForPairs.spec.lua
@@ -229,6 +229,53 @@ return function()
 		expect(quadrupled:get()[8]).to.equal(16)
 	end)
 
+	it("should recalculate its value in response to a dependency change", function()
+		local state = Value({ 
+			[1] = 1,
+			[5] = 5,
+			[10] = 10,
+		 })
+		local increment = Value(1)
+
+		local computed = ForPairs(state, function(key, value)
+			return key + increment:get(), value + increment:get()
+		end)
+
+		expect(computed:get()[1]).never.to.be.ok()
+		expect(computed:get()[5]).never.to.be.ok()
+		expect(computed:get()[10]).never.to.be.ok()
+
+		expect(computed:get()[2]).to.equal(2)
+		expect(computed:get()[6]).to.equal(6)
+		expect(computed:get()[11]).to.equal(11)
+
+		increment:set(2)
+
+		task.wait()
+		task.wait()
+
+		expect(computed:get()[2]).never.to.be.ok()
+		expect(computed:get()[6]).never.to.be.ok()
+		expect(computed:get()[11]).never.to.be.ok()
+
+		expect(computed:get()[3]).to.equal(3)
+		expect(computed:get()[7]).to.equal(7)
+		expect(computed:get()[12]).to.equal(12)
+
+		increment:set(1)
+
+		task.wait()
+		task.wait()
+
+		expect(computed:get()[3]).never.to.be.ok()
+		expect(computed:get()[7]).never.to.be.ok()
+		expect(computed:get()[12]).never.to.be.ok()
+
+		expect(computed:get()[2]).to.equal(2)
+		expect(computed:get()[6]).to.equal(6)
+		expect(computed:get()[11]).to.equal(11)
+	end)
+
 	it("should not corrupt dependencies after an error", function()
 		local state = Value({ 1 })
 		local simulateError = false

--- a/test/State/ForPairs.spec.lua
+++ b/test/State/ForPairs.spec.lua
@@ -175,7 +175,7 @@ return function()
 			["foo"] = "bar",
 		})
 
-		local destructions = 0
+		local metaDataPassed = true
 
 		local _computed = ForPairs(state, function(key, value)
 			local newKey = key .. "biz"
@@ -183,21 +183,32 @@ return function()
 
 			return newKey, newValue, newKey .. newValue
 		end, function(key, value, meta)
-			expect(meta).to.equal(key .. value)
-			destructions += 1
+			if meta ~= key .. value then
+				metaDataPassed = false
+			end
 		end)
 
 		state:set({
 			["foo"] = "baz",
 		})
+		
+		state:set({})
 
-		-- this verifies that the meta expectation passed
-		expect(destructions).to.equal(1)
+		state:set({
+			["foo"] = "bar",
+			["baz"] = "biz",
+			["biz"] = "baz",
+			["buzz"] = "baz",
+			["bar"] = "buzz",
+		})
+
+		state:set({
+			["foo"] = "baz",
+		})
 
 		state:set({})
 
-		-- this verifies that the meta expectation passed
-		expect(destructions).to.equal(2)
+		expect(metaDataPassed).to.equal(true)
 	end)
 
 	it("should recalculate its value in response to State objects", function()

--- a/test/State/ForValues.spec.lua
+++ b/test/State/ForValues.spec.lua
@@ -307,6 +307,51 @@ return function()
 		expect(tripled:get()[2]).to.equal(12)
 	end)
 
+	it("should recalculate its value in response to a dependency change", function()
+		local state = Value({ 
+			[1] = 1,
+			[5] = 5,
+			[10] = 10,
+		 })
+		local increment = Value(1)
+
+		local computed = ForValues(state, function(value)
+			return value + increment:get()
+		end)
+
+		expect(computed:get()[1]).to.equal(2)
+		expect(computed:get()[5]).to.equal(6)
+		expect(computed:get()[10]).to.equal(11)
+
+		increment:set(2)
+
+		task.wait()
+		task.wait()
+
+		expect(computed:get()[1]).to.equal(3)
+		expect(computed:get()[5]).to.equal(7)
+		expect(computed:get()[10]).to.equal(12)
+
+		increment:set(1)
+
+		task.wait()
+		task.wait()
+
+		expect(computed:get()[1]).to.equal(2)
+		expect(computed:get()[5]).to.equal(6)
+		expect(computed:get()[10]).to.equal(11)
+
+		state:set({
+			[1] = 10,
+			[5] = 1,
+			[10] = 5,
+		})
+
+		expect(computed:get()[1]).to.equal(11)
+		expect(computed:get()[5]).to.equal(2)
+		expect(computed:get()[10]).to.equal(6)
+	end)
+
 	it("should not corrupt dependencies after an error", function()
 		local state = Value({
 			[1] = 1,

--- a/test/State/ForValues.spec.lua
+++ b/test/State/ForValues.spec.lua
@@ -54,7 +54,7 @@ return function()
 		expect(calculations).to.equal(2)
 	end)
 
-	it("should only call the processor the first time a constant output value is added", function()
+	it("should only call the processor the first time an output value is added", function()
 		local state = Value({
 			[1] = "foo",
 		})
@@ -80,25 +80,25 @@ return function()
 			[3] = "bar",
 		})
 
-		expect(processorCalls).to.equal(2)
+		expect(processorCalls).to.equal(3)
 
 		state:set({
 			[1] = "bar",
 			[2] = "bar",
 		})
 
-		expect(processorCalls).to.equal(2)
+		expect(processorCalls).to.equal(3)
 
 		state:set({})
 
-		expect(processorCalls).to.equal(2)
+		expect(processorCalls).to.equal(3)
 
 		state:set({
 			[1] = "bar",
 			[2] = "foo",
 		})
 
-		expect(processorCalls).to.equal(4)
+		expect(processorCalls).to.equal(5)
 	end)
 
 	it("should only call the destructor when a constant value gets removed from all indices", function()
@@ -130,13 +130,21 @@ return function()
 		state:set({
 			[1] = "bar",
 			[2] = "bar",
+			[3] = "foo",
+			[4] = "foo",
 		})
 
 		expect(destructions).to.equal(1)
 
+		state:set({
+			[1] = "foo",
+		})
+
+		expect(destructions).to.equal(4)
+
 		state:set({})
 
-		expect(destructions).to.equal(2)
+		expect(destructions).to.equal(5)
 	end)
 
 	it("should only call the destructor when a non-constant value gets removed from all indices", function()
@@ -248,7 +256,7 @@ return function()
 			["fiz"] = "bar",
 		})
 
-		expect(processorCalls).to.equal(3)
+		expect(processorCalls).to.equal(5)
 		expect(destructorCalls).to.equal(2)
 
 		state:set({
@@ -256,13 +264,13 @@ return function()
 			[3] = "baz",
 		})
 
-		expect(processorCalls).to.equal(4)
-		expect(destructorCalls).to.equal(2)
+		expect(processorCalls).to.equal(6)
+		expect(destructorCalls).to.equal(4)
 
 		state:set({})
 
-		expect(processorCalls).to.equal(4)
-		expect(destructorCalls).to.equal(4)
+		expect(processorCalls).to.equal(6)
+		expect(destructorCalls).to.equal(6)
 	end)
 
 	it("should recalculate its value in response to State objects", function()

--- a/test/State/ForValues.spec.lua
+++ b/test/State/ForValues.spec.lua
@@ -14,11 +14,11 @@ end
 
 return function()
 	it("should construct a ForValues object", function()
-		local forKeys = ForValues({}, function() end)
+		local computed = ForValues({}, function() end)
 
-		expect(forKeys).to.be.a("table")
-		expect(forKeys.type).to.equal("State")
-		expect(forKeys.kind).to.equal("ForValues")
+		expect(computed).to.be.a("table")
+		expect(computed.type).to.equal("State")
+		expect(computed.kind).to.equal("ForValues")
 	end)
 
 	it("should calculate and retrieve its value", function()


### PR DESCRIPTION
I've spent the last short while working on a rewrite for ForKeys/ForPairs/ForValues, consisting of the following:

- Fixes an issue with dependency captures when using ``State:get()`` inside of the ``For-xyz`` processor functions.
- ForValues used to always re-use values unless they were a table, or the dependencies change, it has been reworked to have separate values for constants and objects, now working as follows:
![image](https://user-images.githubusercontent.com/55821122/174416678-6893398e-f151-4063-abac-bb954f2613a7.png)
- Added additional unit testing
- Reworked the existing logic to be more readable, and noticeably faster, with new vs old benchmarking as follows:

```
[+] ForKeys
   .......................................................... NEW     ... OLD
   [+] ForKeys with blank input table ....................... 0.75 μs ... 1.24 μs
   [+] ForKeys with changed input state - constant output ... 4.80 μs ... 6.86 μs
   [+] ForKeys with changed input state - dynamic output .... 4.88 μs ... 3.93 μs
   [+] ForKeys with changed input table - constant output ... 2.81 μs ... 4.03 μs
   [+] ForKeys with changed input table - dynamic output .... 2.79 μs ... 4.18 μs
   [+] ForKeys with input state - constant output ........... 2.36 μs ... 4.48 μs
   [+] ForKeys with input state - dynamic output ............ 2.42 μs ... 4.48 μs
   [+] ForKeys with input table - constant output ........... 1.79 μs ... 2.75 μs
   [+] ForKeys with input table - dynamic output ............ 1.86 μs ... 3.07 μs
[+] ForPairs
   .......................................................... NEW     ... OLD
   [+] ForPairs with blank input table ...................... 0.79 μs ... 1.22 μs
   [+] ForPairs with changed input state - constant output .. 4.83 μs ... 6.24 μs
   [+] ForPairs with changed input state - dynamic output ... 5.50 μs ... 7.19 μs
   [+] ForPairs with changed input table - constant output .. 2.73 μs ... 3.53 μs
   [+] ForPairs with changed input table - dynamic output ... 2.84 μs ... 4.10 μs
   [+] ForPairs with input state - constant output .......... 2.18 μs ... 3.07 μs
   [+] ForPairs with input state - dynamic output ........... 2.30 μs ... 3.51 μs
   [+] ForPairs with input table - constant output .......... 1.86 μs ... 2.52 μs
   [+] ForPairs with input table - dynamic output ........... 1.88 μs ... 2.77 μs
[+] ForValues
   .......................................................... NEW     ... OLD
   [+] ForValues with blank input table ..................... 0.76 μs ... 1.16 μs
   [+] ForValues with changed input state - constant output . 4.69 μs ... 6.06 μs
   [+] ForValues with changed input state - dynamic output .. 5.15 μs ... 6.63 μs
   [+] ForValues with changed input table - constant output . 2.69 μs ... 3.38 μs
   [+] ForValues with changed input table - dynamic output .. 2.67 μs ... 3.93 μs
   [+] ForValues with input state - constant output ......... 2.42 μs ... 3.19 μs
   [+] ForValues with input state - dynamic output .......... 2.40 μs ... 3.53 μs
   [+] ForValues with input table - constant output ......... 1.78 μs ... 2.43 μs
   [+] ForValues with input table - dynamic output .......... 1.84 μs ... 2.73 μs
```

It might also be easier to look directly at the edited files instead of looking at the file diffs, you can view each file individually here:

- ForKeys: https://github.com/nottirb/Fusion/blob/for-xyz-rework/src/State/ForKeys.lua
- ForValues: https://github.com/nottirb/Fusion/blob/for-xyz-rework/src/State/ForValues.lua
- ForPairs: https://github.com/nottirb/Fusion/blob/for-xyz-rework/src/State/ForPairs.lua

It is also worth mentioning that some GC tests are failing, though bumping the time they were given fixed them. I have opted to not include time bumps on them in this PR though.

Sorry this took so long, between work, college, and a research position at my college it has taken a while. Please let me know if you see any issues. If you can come up with additional unit tests please let me know and I will implement them. Thanks!
