### PR TITLE
Use capitalized name in project file.

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -1,5 +1,5 @@
 {
-    "name": "fusion",
+    "name": "Fusion",
     "tree": {
         "$path": "src"
     }


### PR DESCRIPTION
When a Rojo project is included as a sub-project, the Name of the root object is set to the name of the project. This would cause Fusion to be built as "fusion", where "Fusion" is expected.