### PR TITLE
Implement SETS algorithm for reactive graph updates

### DIFF
--- a/src/Dependencies/updateAll.lua
+++ b/src/Dependencies/updateAll.lua
@@ -15,9 +15,9 @@ type Descendant = (PubTypes.Dependent & PubTypes.Dependency) | PubTypes.Dependen
 
 -- Credit: https://blog.elttob.uk/2022/11/07/sets-efficient-topological-search.html
 local function updateAll(root: PubTypes.Dependency)
-	local counters = {}
-	local flags = {}
-	local queue = {}
+	local counters: {[Descendant]: number} = {}
+	local flags: {[Descendant]: boolean} = {}
+	local queue: {Descendant} = {}
 	local queueSize = 0
 	local queuePos = 1
 
@@ -32,9 +32,11 @@ local function updateAll(root: PubTypes.Dependency)
 		local next = queue[queuePos]
 		local counter = counters[next]
 		counters[next] = if counter == nil then 1 else counter + 1
-		for object in next.dependentSet do
-			queueSize += 1
-			queue[queueSize] = object
+		if (next :: any).dependentSet ~= nil then
+			for object in (next :: any).dependentSet do
+				queueSize += 1
+				queue[queueSize] = object
+			end
 		end
 		queuePos += 1
 	end
@@ -45,9 +47,10 @@ local function updateAll(root: PubTypes.Dependency)
 		local next = queue[queuePos]
 		local counter = counters[next] - 1
 		counters[next] = counter
-		if counter == 0 and flags[next] and next:update() then
-			for object in next.dependentSet do
-				flags[object] = true
+		if counter == 0 and flags[next] and next:update() and (next :: any).dependentSet ~= nil then
+			for object in (next :: any).dependentSet do
+				queueSize += 1
+				queue[queueSize] = object
 			end
 		end
 		queuePos += 1

--- a/src/Dependencies/updateAll.lua
+++ b/src/Dependencies/updateAll.lua
@@ -13,6 +13,7 @@ local PubTypes = require(Package.PubTypes)
 type Set<T> = {[T]: any}
 type Descendant = (PubTypes.Dependent & PubTypes.Dependency) | PubTypes.Dependent
 
+-- Credit: https://blog.elttob.uk/2022/11/07/sets-efficient-topological-search.html
 local function updateAll(root: PubTypes.Dependency)
 	local counters = {}
 	local flags = {}

--- a/src/Dependencies/updateAll.lua
+++ b/src/Dependencies/updateAll.lua
@@ -13,120 +13,42 @@ local PubTypes = require(Package.PubTypes)
 type Set<T> = {[T]: any}
 type Descendant = (PubTypes.Dependent & PubTypes.Dependency) | PubTypes.Dependent
 
-local function updateAll(ancestor: PubTypes.Dependency)
-	--[[
-		First things first, we need to mark all indirect dependents as needing
-		an update. This means we can ignore any dependencies that aren't related
-		to the current update operation.
-	]]
+local function updateAll(root: PubTypes.Dependency)
+	local counters = {}
+	local flags = {}
+	local queue = {}
 
-	-- set of all dependents that still need to be updated
-	local needsUpdateSet: Set<Descendant> = {}
-	-- the dependents to be processed now
-	local processNow: {Descendant} = {}
-	local processNowSize = 0
-	-- the dependents of the open set to be processed next
-	local processNext: {Descendant} = {}
-	local processNextSize = 0
-
-	-- initialise `processNow` with dependents of ancestor
-	for dependent in pairs(ancestor.dependentSet) do
-		processNowSize += 1
-		processNow[processNowSize] = dependent
+	-- Pass 1: counting up
+	for object in root.dependentSet do
+		table.insert(queue, object)
+	end
+	while #queue > 0 do
+		local next = table.remove(queue, 1)
+		counters[next] = (counters[next] or 0) + 1
+		for object in next.dependentSet do
+			table.insert(queue, object)
+		end
 	end
 
-	repeat
-		-- if we add to `processNext` this will be false, indicating we need to
-		-- process more dependents
-		local processingDone = true
-
-		for _, member in ipairs(processNow) do
-			-- mark this member as needing an update
-			needsUpdateSet[member] = true
-
-			-- add the dependents of the member for processing
-			-- FIXME: Typed Luau doesn't understand this type narrowing yet
-			if (member :: any).dependentSet ~= nil then
-				local member = member :: PubTypes.Dependent & PubTypes.Dependency
-				for dependent in pairs(member.dependentSet) do
-					processNextSize += 1
-					processNext[processNextSize] = dependent
-					processingDone = false
-				end
-			end
-		end
-
-		-- swap in the next dependents to be processed
-		processNow, processNext = processNext, processNow
-		processNowSize, processNextSize = processNextSize, 0
-		table.clear(processNext)
-	until processingDone
-
-	--[[
-		`needsUpdateSet` is now set up. Now that we have this information, we
-		can iterate over the dependents once more and update them only when the
-		relevant dependencies have been updated.
-	]]
-
-	-- re-initialise `processNow` similar to before
-	processNowSize = 0
-	table.clear(processNow)
-	for dependent in pairs(ancestor.dependentSet) do
-		processNowSize += 1
-		processNow[processNowSize] = dependent
+	-- Pass 2: counting down + processing
+	for object in root.dependentSet do
+		table.insert(queue, object)
+		flags[object] = true
 	end
-
-	repeat
-		-- if we add to `processNext` this will be false, indicating we need to
-		-- process more dependents
-		local processingDone = true
-
-		for _, member in ipairs(processNow) do
-			-- mark this member as no longer needing an update
-			needsUpdateSet[member] = nil
-
-			--FUTURE: should this guard against errors?
-			local didChange = member:update()
-
-			-- add the dependents of the member for processing
-			-- optimisation: if nothing changed, then we don't need to add these
-			-- dependents, because they don't need processing.
-			-- FIXME: Typed Luau doesn't understand this type narrowing yet
-			if didChange and (member :: any).dependentSet ~= nil then
-				local member = member :: PubTypes.Dependent & PubTypes.Dependency
-				for dependent in pairs(member.dependentSet) do
-					-- don't add dependents that have un-updated dependencies
-					local allDependenciesUpdated = true
-					for dependentDependency in pairs(dependent.dependencySet) do
-						-- HACK: keys of needsUpdateSet must be Dependents, so
-						-- since we want to ignore non-Dependents, we just type
-						-- cast here regardless of safety
-						if needsUpdateSet[dependentDependency :: any] then
-							allDependenciesUpdated = false
-							break
-						end
-					end
-
-					if allDependenciesUpdated then
-						processNextSize += 1
-						processNext[processNextSize] = dependent
-						processingDone = false
-					end
-				end
+	while #queue > 0 do
+		local next = table.remove(queue, 1)
+		counters[next] -= 1
+		local setFlag = false
+		if counters[next] == 0 and flags[next] then
+			setFlag = next:update()
+		end
+		for object in next.dependentSet do
+			table.insert(queue, object)
+			if setFlag then
+				flags[object] = true
 			end
 		end
-
-		if not processingDone then
-			-- swap in the next dependents to be processed
-			processNow, processNext = processNext, processNow
-			processNowSize, processNextSize = processNextSize, 0
-			table.clear(processNext)
-		end
-	until processingDone
-
-	--[[
-		The update is now complete!
-	]]
+	end
 end
 
 return updateAll

--- a/test/Dependencies/updateAll.spec.lua
+++ b/test/Dependencies/updateAll.spec.lua
@@ -1,0 +1,157 @@
+local Package = game:GetService("ReplicatedStorage").Fusion
+local updateAll = require(Package.Dependencies.updateAll)
+
+local function edge(from, to)
+	return { from = from, to = to }
+end
+
+local function buildReactiveGraph(ancestorsToDescendants, handler)
+	local objects = {}
+
+	local function getObject(named)
+		if objects[named] then
+			return objects[named]
+		end
+		local object = {
+			dependencySet = {},
+			dependentSet = {},
+			update = handler,
+			updates = 0,
+			name = named
+		}
+
+		objects[named] = object
+
+		return object
+	end
+
+	local function relate(ancestor, descendant)
+		ancestor.dependentSet[descendant] = true
+		descendant.dependencySet[ancestor] = true
+	end
+
+	for _, edge in ancestorsToDescendants do
+		local ancestor = getObject(edge.from)
+		local descendant = getObject(edge.to)
+		relate(ancestor, descendant)
+	end
+
+	return objects
+end
+
+return function()
+	it("should update transitive dependencies", function()
+		local objects = buildReactiveGraph({
+			edge("A", "B"),
+			edge("B", "C"),
+			edge("C", "D"),
+		}, function(self)
+			self.updates += 1
+			return true
+		end)
+
+		updateAll(objects.A)
+
+		expect(objects.A.updates).to.equal(0)
+		expect(objects.B.updates).to.equal(1)
+		expect(objects.C.updates).to.equal(1)
+		expect(objects.D.updates).to.equal(1)
+	end)
+
+	it("should only update objects once", function()
+		local objects = buildReactiveGraph({
+			edge("A", "B"), edge("A", "C"),
+			edge("B", "D"), edge("C", "D"),
+		}, function(self)
+			self.updates += 1
+			return true
+		end)
+
+		updateAll(objects.A)
+
+		expect(objects.A.updates).to.equal(0)
+		expect(objects.B.updates).to.equal(1)
+		expect(objects.C.updates).to.equal(1)
+		expect(objects.D.updates).to.equal(1)
+	end)
+
+	it("should not update unchanged subgraphs", function()
+		local objects = buildReactiveGraph({
+			edge("A", "B"),
+			edge("B", "C"),
+			edge("C", "D"),
+		}, function(self)
+			self.updates += 1
+			return if self.name == "C" then false else true
+		end)
+
+		updateAll(objects.A)
+
+		expect(objects.A.updates).to.equal(0)
+		expect(objects.B.updates).to.equal(1)
+		expect(objects.C.updates).to.equal(1)
+		expect(objects.D.updates).to.equal(0)
+	end)
+
+	it("should update state objects in subgraphs of unchanged state objects", function()
+		local objects = buildReactiveGraph({
+			edge("A", "B"), edge("A", "D"),
+			edge("B", "C"),
+			edge("C", "E"),
+			edge("D", "F"),
+			edge("E", "F"),
+		}, function(self)
+			self.updates += 1
+			if self.name == "B" then
+				return false
+			else
+				return true
+			end
+		end)
+
+		updateAll(objects.A)
+
+		expect(objects.A.updates).to.equal(0)
+		expect(objects.B.updates).to.equal(1)
+		expect(objects.C.updates).to.equal(0)
+		expect(objects.D.updates).to.equal(1)
+		expect(objects.E.updates).to.equal(1)
+		expect(objects.F.updates).to.equal(1)
+	end)
+
+	it("should update complicated graphs correctly", function()
+		local objects = buildReactiveGraph({
+			edge("A", "B"), edge("A", "F"), edge("A", "I"),
+			edge("B", "C"), edge("B", "D"), edge("B", "E"),
+			edge("C", "E"), edge("C", "G"),
+			edge("D", "F"),
+			edge("E", "H"),
+			edge("F", "I"),
+			edge("G", "J"),
+			edge("H", "J"),
+			edge("I", "J"),
+		}, function(self)
+			self.updates += 1
+			if self.name == "C" or self.name == "D" or self.name == "E" then
+				return false
+			else
+				return true
+			end
+		end)
+
+		updateAll(objects.A)
+
+		expect(objects.A.updates).to.equal(0)
+		expect(objects.B.updates).to.equal(1)
+		expect(objects.C.updates).to.equal(1)
+		expect(objects.D.updates).to.equal(1)
+		expect(objects.E.updates).to.equal(1)
+		expect(objects.F.updates).to.equal(1)
+		expect(objects.G.updates).to.equal(0)
+		expect(objects.H.updates).to.equal(0)
+		expect(objects.I.updates).to.equal(1)
+		expect(objects.J.updates).to.equal(1)
+	end)
+
+	-- TODO: test in conjunction with initDependency
+end

--- a/test/Dependencies/updateAll.spec.lua
+++ b/test/Dependencies/updateAll.spec.lua
@@ -98,7 +98,7 @@ return function()
 			edge("A", "B"), edge("A", "D"),
 			edge("B", "C"),
 			edge("C", "E"),
-			edge("D", "F"),
+			edge("D", "E"),
 			edge("E", "F"),
 		}, function(self)
 			self.updates += 1

--- a/test/Dependencies/updateAll.spec.lua
+++ b/test/Dependencies/updateAll.spec.lua
@@ -152,6 +152,4 @@ return function()
 		expect(objects.I.updates).to.equal(1)
 		expect(objects.J.updates).to.equal(1)
 	end)
-
-	-- TODO: test in conjunction with initDependency
 end


### PR DESCRIPTION
Fixes #190 by reimplementing `updateAll()` to use the newer SETS algorithm, which should fix a nasty edge case in reactive graph updates that can occur rarely in specific circumstances.

Also includes unit tests to catch these errors in future.