### PR TITLE
Implement attribute support into New function.

### DIFF
--- a/src/Instances/Attribute.lua
+++ b/src/Instances/Attribute.lua
@@ -27,9 +27,8 @@ local function bindAttribute(instance: Instance, attribute: string, value: any, 
                 end)
             end
         end
-
-		setAttribute(instance, attribute, value:get(false))
-		table.insert(cleanupTasks, Observer(value :: any):onChange(update))
+	    setAttribute(instance, attribute, value:get(false))
+	    table.insert(cleanupTasks, Observer(value :: any):onChange(update))
     else
         setAttribute(instance, attribute, value)
     end
@@ -44,11 +43,10 @@ local function Attribute(attributeName: string): PubTypes.SpecialKey
     if attributeName == nil then
         logError("attributeNameNil")
     end
-    
+
     function AttributeKey:apply(attributeValue: any, applyTo: Instance, cleanupTasks: {PubTypes.Task})
         bindAttribute(applyTo, attributeName, attributeValue, cleanupTasks)
     end
-
     return AttributeKey
 end
 

--- a/src/Instances/Attribute.lua
+++ b/src/Instances/Attribute.lua
@@ -41,10 +41,11 @@ local function Attribute(attributeName: string)
     AttributeKey.kind = "Attribute"
     AttributeKey.stage = "self"
 
+    if attributeName == nil then
+        logError("attributeNameNil")
+    end
+    
     function AttributeKey:apply(attributeValue: any, applyTo: Instance, cleanupTasks: {PubTypes.Task})
-        if attributeName == nil then
-            logError("attributeNameNil")
-        end
         bindAttribute(applyTo, attributeName, attributeValue, cleanupTasks)
     end
     return AttributeKey

--- a/src/Instances/Attribute.lua
+++ b/src/Instances/Attribute.lua
@@ -1,0 +1,49 @@
+--!strict
+
+--[[
+	A special key for property tables, which allows users to apply custom
+    attributes to instances
+]]
+
+local Package = script.Parent.Parent
+local PubTypes = require(Package.PubTypes)
+local logError = require(Package.Logging.logError)
+local xtypeof = require(Package.Utility.xtypeof)
+local Observer = require(Package.State.Observer)
+
+local function setAttribute(instance: Instance, attribute: string, value: any)
+    instance:SetAttribute(attribute, value)
+end
+
+local function bindAttribute(instance: Instance, attribute: string, value: any, cleanupTasks: {PubTypes.Task})
+    if xtypeof(value) == "State" then
+		setAttribute(instance, attribute, value:get(false))
+		table.insert(cleanupTasks, Observer(value :: any):onChange(function()
+            setAttribute(instance, attribute, value:get(false))
+        end))
+    else
+        setAttribute(instance, attribute, value)
+    end
+end
+
+local function Attribute(attributeName: string)
+    local AttributeKey = {}
+    AttributeKey.type = "SpecialKey"
+    AttributeKey.kind = "Attribute"
+    AttributeKey.stage = "self"
+
+    function AttributeKey:apply(attributeValue: any, applyTo: Instance, cleanupTasks: {PubTypes.Task})
+        --[[
+            [Attribute "Test"] = "Hi",
+            [Attribute "Test"] = ammo,
+            [Attribute "Test"] = Computed(function()
+                return loaded:get() and 50 or 75
+            end)
+        ]]
+        
+        bindAttribute(applyTo, attributeName, attributeValue, cleanupTasks)
+    end
+    return AttributeKey
+end
+
+return Attribute

--- a/src/Instances/Attribute.lua
+++ b/src/Instances/Attribute.lua
@@ -35,7 +35,7 @@ local function bindAttribute(instance: Instance, attribute: string, value: any, 
     end
 end
 
-local function Attribute(attributeName: string)
+local function Attribute(attributeName: string): PubTypes.SpecialKey
     local AttributeKey = {}
     AttributeKey.type = "SpecialKey"
     AttributeKey.kind = "Attribute"

--- a/src/Instances/Attribute.lua
+++ b/src/Instances/Attribute.lua
@@ -20,12 +20,12 @@ local function bindAttribute(instance: Instance, attribute: string, value: any, 
         local didDefer = false
         local function update()
             if not didDefer then
-				didDefer = true
-				task.defer(function()
-					didDefer = false
-					setAttribute(instance, attribute, value:get(false))
-				end)
-			end
+                didDefer = true
+                    task.defer(function()
+                    didDefer = false
+                    setAttribute(instance, attribute, value:get(false))
+                end)
+            end
         end
 
 		setAttribute(instance, attribute, value:get(false))
@@ -48,6 +48,7 @@ local function Attribute(attributeName: string): PubTypes.SpecialKey
     function AttributeKey:apply(attributeValue: any, applyTo: Instance, cleanupTasks: {PubTypes.Task})
         bindAttribute(applyTo, attributeName, attributeValue, cleanupTasks)
     end
+
     return AttributeKey
 end
 

--- a/src/Instances/Attribute.lua
+++ b/src/Instances/Attribute.lua
@@ -33,14 +33,6 @@ local function Attribute(attributeName: string)
     AttributeKey.stage = "self"
 
     function AttributeKey:apply(attributeValue: any, applyTo: Instance, cleanupTasks: {PubTypes.Task})
-        --[[
-            [Attribute "Test"] = "Hi",
-            [Attribute "Test"] = ammo,
-            [Attribute "Test"] = Computed(function()
-                return loaded:get() and 50 or 75
-            end)
-        ]]
-        
         bindAttribute(applyTo, attributeName, attributeValue, cleanupTasks)
     end
     return AttributeKey

--- a/src/Instances/AttributeChange.lua
+++ b/src/Instances/AttributeChange.lua
@@ -17,15 +17,15 @@ local function AttributeChange(attributeName: string): PubTypes.SpecialKey
 	attributeKey.stage = "observer"
 
 	if attributeName == nil then
-        logError("attributeNameNil")
-    end
+    	logError("attributeNameNil")
+	end
 
 	function attributeKey:apply(callback: any, applyTo: Instance, cleanupTasks: {PubTypes.Task})
 		if typeof(callback) ~= "function" then
 			logError("invalidAttributeChangeHandler", nil, attributeName)
 		end
 
-    	local ok, event = pcall(applyTo.GetAttributeChangedSignal, applyTo, attributeName)
+		local ok, event = pcall(applyTo.GetAttributeChangedSignal, applyTo, attributeName)
 		if not ok then
 			logError("cannotConnectAttributeChange", nil, applyTo.ClassName, attributeName)
 		else
@@ -34,7 +34,7 @@ local function AttributeChange(attributeName: string): PubTypes.SpecialKey
 				callback((applyTo :: any):GetAttribute(attributeName))
 			end))
 		end
-    end
+	end
 
 	return attributeKey
 end

--- a/src/Instances/AttributeChange.lua
+++ b/src/Instances/AttributeChange.lua
@@ -10,7 +10,7 @@ local PubTypes = require(Package.PubTypes)
 local logError = require(Package.Logging.logError)
 local xtypeof = require(Package.Utility.xtypeof)
 
-local function AttributeChanged(attributeName: string): PubTypes.SpecialKey
+local function AttributeChange(attributeName: string): PubTypes.SpecialKey
 	local attributeKey = {}
 	attributeKey.type = "SpecialKey"
 	attributeKey.kind = "AttributeChange"
@@ -39,4 +39,4 @@ local function AttributeChanged(attributeName: string): PubTypes.SpecialKey
 	return attributeKey
 end
 
-return AttributeChanged
+return AttributeChange

--- a/src/Instances/AttributeChange.lua
+++ b/src/Instances/AttributeChange.lua
@@ -16,12 +16,18 @@ local function AttributeChanged(attributeName: string): PubTypes.SpecialKey
 	attributeKey.kind = "AttributeChange"
 	attributeKey.stage = "observer"
 
-    function attributeKey:apply(callback: any, applyTo: Instance, cleanupTasks: {PubTypes.Task})
-        local ok, event = pcall(applyTo.GetAttributeChangedSignal, applyTo, attributeName)
+	if attributeName == nil then
+        logError("attributeNameNil")
+    end
+
+	function attributeKey:apply(callback: any, applyTo: Instance, cleanupTasks: {PubTypes.Task})
+		if typeof(callback) ~= "function" then
+			logError("invalidAttributeChangeHandler", nil, attributeName)
+		end
+
+    	local ok, event = pcall(applyTo.GetAttributeChangedSignal, applyTo, attributeName)
 		if not ok then
 			logError("cannotConnectAttributeChange", nil, applyTo.ClassName, attributeName)
-		elseif typeof(callback) ~= "function" then
-			logError("invalidAttributeChangeHandler", nil, attributeName)
 		else
 			callback((applyTo :: any):GetAttribute(attributeName))
 			table.insert(cleanupTasks, event:Connect(function()

--- a/src/Instances/AttributeChange.lua
+++ b/src/Instances/AttributeChange.lua
@@ -1,0 +1,36 @@
+--!strict
+
+--[[
+	A special key for property tables, which allows users to connect to
+    an attribute change on an instance.
+]]
+
+local Package = script.Parent.Parent
+local PubTypes = require(Package.PubTypes)
+local logError = require(Package.Logging.logError)
+local xtypeof = require(Package.Utility.xtypeof)
+
+local function AttributeChanged(attributeName: string): PubTypes.SpecialKey
+	local attributeKey = {}
+	attributeKey.type = "SpecialKey"
+	attributeKey.kind = "AttributeChange"
+	attributeKey.stage = "observer"
+
+    function attributeKey:apply(callback: any, applyTo: Instance, cleanupTasks: {PubTypes.Task})
+        local ok, event = pcall(applyTo.GetAttributeChangedSignal, applyTo, attributeName)
+		if not ok then
+			logError("cannotConnectAttributeChange", nil, applyTo.ClassName, attributeName)
+		elseif typeof(callback) ~= "function" then
+			logError("invalidAttributeChangeHandler", nil, attributeName)
+		else
+			callback((applyTo :: any):GetAttribute(attributeName))
+			table.insert(cleanupTasks, event:Connect(function()
+				callback((applyTo :: any):GetAttribute(attributeName))
+			end))
+		end
+    end
+
+	return attributeKey
+end
+
+return AttributeChanged

--- a/src/Instances/AttributeChange.lua
+++ b/src/Instances/AttributeChange.lua
@@ -24,7 +24,6 @@ local function AttributeChange(attributeName: string): PubTypes.SpecialKey
 		if typeof(callback) ~= "function" then
 			logError("invalidAttributeChangeHandler", nil, attributeName)
 		end
-
 		local ok, event = pcall(applyTo.GetAttributeChangedSignal, applyTo, attributeName)
 		if not ok then
 			logError("cannotConnectAttributeChange", nil, applyTo.ClassName, attributeName)
@@ -35,7 +34,6 @@ local function AttributeChange(attributeName: string): PubTypes.SpecialKey
 			end))
 		end
 	end
-
 	return attributeKey
 end
 

--- a/src/Instances/AttributeOut.lua
+++ b/src/Instances/AttributeOut.lua
@@ -20,11 +20,9 @@ local function AttributeOut(attributeName: string): PubTypes.SpecialKey
 		if xtypeof(stateObject) ~= "State" or stateObject.kind ~= "Value" then
 			logError("invalidAttributeOutType")
 		end
-
 		if attributeName == nil then
 			logError("attributeNameNil")
 		end
-
 		local ok, event = pcall(applyTo.GetAttributeChangedSignal, applyTo, attributeName)
 		if not ok then
 			logError("invalidOutAttributeName", applyTo.ClassName, attributeName)

--- a/src/Instances/AttributeOut.lua
+++ b/src/Instances/AttributeOut.lua
@@ -1,0 +1,45 @@
+--!strict
+
+--[[
+	A special key for property tables, which allows users to save instance attributes
+    into state objects
+]]
+
+local Package = script.Parent.Parent
+local PubTypes = require(Package.PubTypes)
+local logError = require(Package.Logging.logError)
+local xtypeof = require(Package.Utility.xtypeof)
+
+local function AttributeOut(attributeName: string): PubTypes.SpecialKey
+	local attributeOutKey = {}
+	attributeOutKey.type = "SpecialKey"
+	attributeOutKey.kind = "AttributeOut"
+	attributeOutKey.stage = "observer"
+
+	function attributeOutKey:apply(stateObject: PubTypes.StateObject, applyTo: Instance, cleanupTasks: { PubTypes.Task })
+		if xtypeof(stateObject) ~= "State" or stateObject.kind ~= "Value" then
+			logError("invalidAttributeOutType")
+        end
+
+        if attributeName == nil then
+            logError("attributeNameNil")
+        end
+
+        local ok, event = pcall(applyTo.GetAttributeChangedSignal, applyTo, attributeName)
+		if not ok then
+			logError("unknownMessage", "Major error occurred while calling GetAttributeChangedSignal.")
+		else
+			stateObject:set((applyTo :: any):GetAttribute(attributeName))
+			table.insert(cleanupTasks, event:Connect(function()
+				stateObject:set((applyTo :: any):GetAttribute(attributeName))
+			end))
+			table.insert(cleanupTasks, function()
+				stateObject:set(nil)
+			end)
+		end
+	end
+
+	return attributeOutKey
+end
+
+return AttributeOut

--- a/src/Instances/AttributeOut.lua
+++ b/src/Instances/AttributeOut.lua
@@ -19,18 +19,18 @@ local function AttributeOut(attributeName: string): PubTypes.SpecialKey
 	function attributeOutKey:apply(stateObject: PubTypes.StateObject, applyTo: Instance, cleanupTasks: { PubTypes.Task })
 		if xtypeof(stateObject) ~= "State" or stateObject.kind ~= "Value" then
 			logError("invalidAttributeOutType")
-        end
+		end
 
-        if attributeName == nil then
-            logError("attributeNameNil")
-        end
+		if attributeName == nil then
+			logError("attributeNameNil")
+		end
 
-        local ok, event = pcall(applyTo.GetAttributeChangedSignal, applyTo, attributeName)
+		local ok, event = pcall(applyTo.GetAttributeChangedSignal, applyTo, attributeName)
 		if not ok then
 			logError("invalidOutAttributeName", applyTo.ClassName, attributeName)
 		else
 			stateObject:set((applyTo :: any):GetAttribute(attributeName))
-			table.insert(cleanupTasks, event:Connect(function()
+			table.insert(cleanupTasks, event:Connect(function()	
 				stateObject:set((applyTo :: any):GetAttribute(attributeName))
 			end))
 			table.insert(cleanupTasks, function()

--- a/src/Instances/AttributeOut.lua
+++ b/src/Instances/AttributeOut.lua
@@ -27,7 +27,7 @@ local function AttributeOut(attributeName: string): PubTypes.SpecialKey
 
         local ok, event = pcall(applyTo.GetAttributeChangedSignal, applyTo, attributeName)
 		if not ok then
-			logError("unknownMessage", "Major error occurred while calling GetAttributeChangedSignal.")
+			logError("invalidOutAttributeName", applyTo.ClassName, attributeName)
 		else
 			stateObject:set((applyTo :: any):GetAttribute(attributeName))
 			table.insert(cleanupTasks, event:Connect(function()

--- a/src/Logging/messages.lua
+++ b/src/Logging/messages.lua
@@ -28,7 +28,7 @@ return {
 	forValuesProcessorError = "ForValues callback error: ERROR_MESSAGE",
 	forValuesDestructorError = "ForValues destructor error: ERROR_MESSAGE",
 	invalidChangeHandler = "The change handler for the '%s' property must be a function.",
-	invalidAttributeChangeHandler = "The attribute change handler for the '%s' property must be a function.",
+	invalidAttributeChangeHandler = "The change handler for the '%s' attribute must be a function.",
 	invalidEventHandler = "The handler for the '%s' event must be a function.",
 	invalidPropertyType = "'%s.%s' expected a '%s' type, but got a '%s' type.",
 	invalidRefType = "Instance refs must be Value objects.",

--- a/src/Logging/messages.lua
+++ b/src/Logging/messages.lua
@@ -33,7 +33,7 @@ return {
 	invalidPropertyType = "'%s.%s' expected a '%s' type, but got a '%s' type.",
 	invalidRefType = "Instance refs must be Value objects.",
 	invalidOutType = "[Out] properties must be given Value objects.",
-	invalidAttributeOutType = "[AttributeOut] properties must be given Value objects."
+	invalidAttributeOutType = "[AttributeOut] properties must be given Value objects.",
 	invalidOutProperty = "The %s class doesn't have a property called '%s'.",
 	invalidSpringDamping = "The damping ratio for a spring must be >= 0. (damping was %.2f)",
 	invalidSpringSpeed = "The speed of a spring must be >= 0. (speed was %.2f)",

--- a/src/Logging/messages.lua
+++ b/src/Logging/messages.lua
@@ -5,6 +5,7 @@
 ]]
 
 return {
+	attributeNameNil = "Attribute name cannot be nil",
 	cannotAssignProperty = "The class type '%s' has no assignable property '%s'.",
 	cannotConnectChange = "The %s class doesn't have a property called '%s'.",
 	cannotConnectAttributeChange = "The %s class doesn't have an attribute called '%s'.",

--- a/src/Logging/messages.lua
+++ b/src/Logging/messages.lua
@@ -33,6 +33,7 @@ return {
 	invalidPropertyType = "'%s.%s' expected a '%s' type, but got a '%s' type.",
 	invalidRefType = "Instance refs must be Value objects.",
 	invalidOutType = "[Out] properties must be given Value objects.",
+	invalidAttributeOutType = "[AttributeOut] properties must be given Value objects."
 	invalidOutProperty = "The %s class doesn't have a property called '%s'.",
 	invalidSpringDamping = "The damping ratio for a spring must be >= 0. (damping was %.2f)",
 	invalidSpringSpeed = "The speed of a spring must be >= 0. (speed was %.2f)",

--- a/src/Logging/messages.lua
+++ b/src/Logging/messages.lua
@@ -35,6 +35,7 @@ return {
 	invalidOutType = "[Out] properties must be given Value objects.",
 	invalidAttributeOutType = "[AttributeOut] properties must be given Value objects.",
 	invalidOutProperty = "The %s class doesn't have a property called '%s'.",
+	invalidOutAttributeName = "The %s class doesn't have an attribute called '%s'.",
 	invalidSpringDamping = "The damping ratio for a spring must be >= 0. (damping was %.2f)",
 	invalidSpringSpeed = "The speed of a spring must be >= 0. (speed was %.2f)",
 	mistypedSpringDamping = "The damping ratio for a spring must be a number. (got a %s)",

--- a/src/Logging/messages.lua
+++ b/src/Logging/messages.lua
@@ -7,6 +7,7 @@
 return {
 	cannotAssignProperty = "The class type '%s' has no assignable property '%s'.",
 	cannotConnectChange = "The %s class doesn't have a property called '%s'.",
+	cannotConnectAttributeChange = "The %s class doesn't have an attribute called '%s'.",
 	cannotConnectEvent = "The %s class doesn't have an event called '%s'.",
 	cannotCreateClass = "Can't create a new instance of class '%s'.",
 	computedCallbackError = "Computed callback error: ERROR_MESSAGE",
@@ -26,6 +27,7 @@ return {
 	forValuesProcessorError = "ForValues callback error: ERROR_MESSAGE",
 	forValuesDestructorError = "ForValues destructor error: ERROR_MESSAGE",
 	invalidChangeHandler = "The change handler for the '%s' property must be a function.",
+	invalidAttributeChangeHandler = "The attribute change handler for the '%s' property must be a function.",
 	invalidEventHandler = "The handler for the '%s' event must be a function.",
 	invalidPropertyType = "'%s.%s' expected a '%s' type, but got a '%s' type.",
 	invalidRefType = "Instance refs must be Value objects.",

--- a/src/PubTypes.lua
+++ b/src/PubTypes.lua
@@ -46,6 +46,23 @@ export type Task =
 	{Destroy: (any) -> ()} |
 	{Task}
 
+-- Types that can be used as attributes
+
+export type Attribute = 
+	string |
+	boolean |
+	number |
+	UDim |
+	UDim2 |
+	BrickColor |
+	Color3 |
+	Vector2 |
+	Vector3 |
+	NumberSequence |
+	ColorSequence |
+	NumberRange |
+	Rect
+
 -- Script-readable version information.
 export type Version = {
 	major: number,

--- a/src/PubTypes.lua
+++ b/src/PubTypes.lua
@@ -46,23 +46,6 @@ export type Task =
 	{Destroy: (any) -> ()} |
 	{Task}
 
--- Types that can be used as attributes
-
-export type Attribute = 
-	string |
-	boolean |
-	number |
-	UDim |
-	UDim2 |
-	BrickColor |
-	Color3 |
-	Vector2 |
-	Vector3 |
-	NumberSequence |
-	ColorSequence |
-	NumberRange |
-	Rect
-
 -- Script-readable version information.
 export type Version = {
 	major: number,

--- a/src/init.lua
+++ b/src/init.lua
@@ -32,6 +32,7 @@ type Fusion = {
 	OnChange: (propertyName: string) -> PubTypes.SpecialKey,
 	Attribute: (attributeName: string) -> PubTypes.SpecialKey,
 	AttributeChanged: (attributeName: string) -> PubTypes.SpecialKey,
+	AttributeOut: (attributeName: string) -> PubTypes.SpecialKey,
 
 	Value: <T>(initialValue: T) -> Value<T>,
 	Computed: <T>(callback: () -> T, destructor: (T) -> ()?) -> Computed<T>,
@@ -60,6 +61,7 @@ return restrictRead("Fusion", {
 	OnChange = require(script.Instances.OnChange),
 	Attribute = require(script.Instances.Attribute),
 	AttributeChanged = require(script.Instances.AttributeChanged),
+	AttributeOut = require(script.Instances.AttributeOut),
 
 	Value = require(script.State.Value),
 	Computed = require(script.State.Computed),

--- a/src/init.lua
+++ b/src/init.lua
@@ -31,7 +31,7 @@ type Fusion = {
 	OnEvent: (eventName: string) -> PubTypes.SpecialKey,
 	OnChange: (propertyName: string) -> PubTypes.SpecialKey,
 	Attribute: (attributeName: string) -> PubTypes.SpecialKey,
-	AttributeChanged: (attributeName: string) -> PubTypes.SpecialKey,
+	AttributeChange: (attributeName: string) -> PubTypes.SpecialKey,
 	AttributeOut: (attributeName: string) -> PubTypes.SpecialKey,
 
 	Value: <T>(initialValue: T) -> Value<T>,

--- a/src/init.lua
+++ b/src/init.lua
@@ -30,6 +30,8 @@ type Fusion = {
 	Out: PubTypes.SpecialKey,
 	OnEvent: (eventName: string) -> PubTypes.SpecialKey,
 	OnChange: (propertyName: string) -> PubTypes.SpecialKey,
+	Attribute: (attributeName: string) -> PubTypes.SpecialKey,
+	AttributeChanged: (attributeName: string) -> PubTypes.SpecialKey,
 
 	Value: <T>(initialValue: T) -> Value<T>,
 	Computed: <T>(callback: () -> T, destructor: (T) -> ()?) -> Computed<T>,
@@ -56,6 +58,8 @@ return restrictRead("Fusion", {
 	Children = require(script.Instances.Children),
 	OnEvent = require(script.Instances.OnEvent),
 	OnChange = require(script.Instances.OnChange),
+	Attribute = require(script.Instances.Attribute),
+	AttributeChanged = require(script.Instances.AttributeChanged),
 
 	Value = require(script.State.Value),
 	Computed = require(script.State.Computed),

--- a/src/init.lua
+++ b/src/init.lua
@@ -60,7 +60,7 @@ return restrictRead("Fusion", {
 	OnEvent = require(script.Instances.OnEvent),
 	OnChange = require(script.Instances.OnChange),
 	Attribute = require(script.Instances.Attribute),
-	AttributeChanged = require(script.Instances.AttributeChanged),
+	AttributeChange = require(script.Instances.AttributeChange),
 	AttributeOut = require(script.Instances.AttributeOut),
 
 	Value = require(script.State.Value),

--- a/test/Instances/Attribute.spec.lua
+++ b/test/Instances/Attribute.spec.lua
@@ -4,7 +4,7 @@ local New = require(Package.Instances.New)
 local Attribute = require(Package.Instances.Attribute)
 local Value = require(Package.State.Value)
 
-return function()
+return function ()
     it("should create attributes (constant)", function()
         local child = New "Folder" {
             [Attribute "Foo"] = "Bar"
@@ -14,15 +14,15 @@ return function()
 
     it("should create attributes (state)", function()
         local attributeValue = Value("Bar")
-	    local child = New "Folder" {
+        local child = New "Folder" {
             [Attribute "Foo"] = attributeValue
         }
         expect(child:GetAttribute("Foo")).to.equal("Bar")
     end)
-
+    
     it("should update attributes when state objects are updated", function()
         local attributeValue = Value("Bar")
-	    local child = New "Folder" {
+        local child = New "Folder" {
             [Attribute "Foo"] = attributeValue
         }
         expect(child:GetAttribute("Foo")).to.equal("Bar")

--- a/test/Instances/Attribute.spec.lua
+++ b/test/Instances/Attribute.spec.lua
@@ -1,0 +1,27 @@
+local Package = game:GetService("ReplicatedStorage").Fusion
+
+local New = require(Package.Instances.New)
+local Attribute = require(Package.Instances.Attribute)
+local Value = require(Package.State.Value)
+
+return function()
+	it("should assign constant attributes to objects", function()
+		local child = New "Folder" {
+            [Attribute "Test"] = "AttributeOne"
+        }
+
+        expect(child:GetAttribute("Test")).to.equal("AttributeOne")
+	end)
+
+    it("should bind attributes to state objects", function()
+        local attributeValue = Value("AttributeOne")
+		local child = New "Folder" {
+            [Attribute "Test"] = attributeValue
+        }
+
+        expect(child:GetAttribute("Test")).to.equal("AttributeOne")
+        attributeValue:set("AttributeTwo")
+        task.wait()
+        expect(child:GetAttribute("Test")).to.equal("AttributeTwo")
+	end)
+end

--- a/test/Instances/Attribute.spec.lua
+++ b/test/Instances/Attribute.spec.lua
@@ -5,25 +5,24 @@ local Attribute = require(Package.Instances.Attribute)
 local Value = require(Package.State.Value)
 
 return function()
-	it("should create attributes (constant)", function()
-		local child = New "Folder" {
+    it("should create attributes (constant)", function()
+        local child = New "Folder" {
             [Attribute "Foo"] = "Bar"
         }
         expect(child:GetAttribute("Foo")).to.equal("Bar")
-	end)
+    end)
 
     it("should create attributes (state)", function()
         local attributeValue = Value("Bar")
-		local child = New "Folder" {
+	    local child = New "Folder" {
             [Attribute "Foo"] = attributeValue
         }
-
         expect(child:GetAttribute("Foo")).to.equal("Bar")
-	end)
+    end)
 
     it("should update attributes when state objects are updated", function()
         local attributeValue = Value("Bar")
-		local child = New "Folder" {
+	    local child = New "Folder" {
             [Attribute "Foo"] = attributeValue
         }
 
@@ -50,16 +49,15 @@ return function()
         end).to.throw("attributeNameNil")
     end)
 
-
     it("should defer attribute changes", function()
-		local value = Value("Bar")
-		local child = New "Folder" {
+	    local value = Value("Bar")
+	    local child = New "Folder" {
             [Attribute "Foo"] = value
         }
 		value:set("Baz")
 
-		expect(child:GetAttribute("Foo")).to.equal("Bar")
-		task.wait()
-		expect(child:GetAttribute("Foo")).to.equal("Baz")
+	    expect(child:GetAttribute("Foo")).to.equal("Bar")
+	    task.wait()
+	    expect(child:GetAttribute("Foo")).to.equal("Baz")
 	end)
 end

--- a/test/Instances/Attribute.spec.lua
+++ b/test/Instances/Attribute.spec.lua
@@ -49,13 +49,13 @@ return function ()
     end)
 
     it("should defer attribute changes", function()
-	    local value = Value("Bar")
-	    local child = New "Folder" {
+        local value = Value("Bar")
+        local child = New "Folder" {
             [Attribute "Foo"] = value
         }
-	    value:set("Baz")
-	    expect(child:GetAttribute("Foo")).to.equal("Bar")
-	    task.wait()
-	    expect(child:GetAttribute("Foo")).to.equal("Baz")
+        value:set("Baz")
+        expect(child:GetAttribute("Foo")).to.equal("Bar")
+        task.wait()
+        expect(child:GetAttribute("Foo")).to.equal("Baz")
     end)
 end

--- a/test/Instances/Attribute.spec.lua
+++ b/test/Instances/Attribute.spec.lua
@@ -4,7 +4,7 @@ local New = require(Package.Instances.New)
 local Attribute = require(Package.Instances.Attribute)
 local Value = require(Package.State.Value)
 
-return function ()
+return function()
     it("should create attributes (constant)", function()
         local child = New "Folder" {
             [Attribute "Foo"] = "Bar"

--- a/test/Instances/Attribute.spec.lua
+++ b/test/Instances/Attribute.spec.lua
@@ -5,23 +5,61 @@ local Attribute = require(Package.Instances.Attribute)
 local Value = require(Package.State.Value)
 
 return function()
-	it("should assign constant attributes to objects", function()
+	it("should create attributes (constant)", function()
 		local child = New "Folder" {
-            [Attribute "Test"] = "AttributeOne"
+            [Attribute "Foo"] = "Bar"
         }
-
-        expect(child:GetAttribute("Test")).to.equal("AttributeOne")
+        expect(child:GetAttribute("Foo")).to.equal("Bar")
 	end)
 
-    it("should bind attributes to state objects", function()
-        local attributeValue = Value("AttributeOne")
+    it("should create attributes (state)", function()
+        local attributeValue = Value("Bar")
 		local child = New "Folder" {
-            [Attribute "Test"] = attributeValue
+            [Attribute "Foo"] = attributeValue
         }
 
-        expect(child:GetAttribute("Test")).to.equal("AttributeOne")
-        attributeValue:set("AttributeTwo")
+        expect(child:GetAttribute("Foo")).to.equal("Bar")
+	end)
+
+    it("should update attributes when state objects are updated", function()
+        local attributeValue = Value("Bar")
+		local child = New "Folder" {
+            [Attribute "Foo"] = attributeValue
+        }
+
+        expect(child:GetAttribute("Foo")).to.equal("Bar")
+        attributeValue:set("Baz")
         task.wait()
-        expect(child:GetAttribute("Test")).to.equal("AttributeTwo")
+        expect(child:GetAttribute("Foo")).to.equal("Baz")
+    end)
+
+    it("should error when given nil names (constant)", function()
+        expect(function()
+            local child = New "Folder" {
+                [Attribute(nil)] = "foo"
+            }
+        end).to.throw("attributeNameNil")
+    end)
+
+    it("should error when given nil names (state)", function()
+        expect(function()
+            local attributeValue = Value("foo")
+            local child = New "Folder" {
+                [Attribute(nil)] = attributeValue
+            }
+        end).to.throw("attributeNameNil")
+    end)
+
+
+    it("should defer attribute changes", function()
+		local value = Value("Bar")
+		local child = New "Folder" {
+            [Attribute "Foo"] = value
+        }
+		value:set("Baz")
+
+		expect(child:GetAttribute("Foo")).to.equal("Bar")
+		task.wait()
+		expect(child:GetAttribute("Foo")).to.equal("Baz")
 	end)
 end

--- a/test/Instances/Attribute.spec.lua
+++ b/test/Instances/Attribute.spec.lua
@@ -25,7 +25,6 @@ return function()
 	    local child = New "Folder" {
             [Attribute "Foo"] = attributeValue
         }
-
         expect(child:GetAttribute("Foo")).to.equal("Bar")
         attributeValue:set("Baz")
         task.wait()
@@ -54,10 +53,9 @@ return function()
 	    local child = New "Folder" {
             [Attribute "Foo"] = value
         }
-		value:set("Baz")
-
+	    value:set("Baz")
 	    expect(child:GetAttribute("Foo")).to.equal("Bar")
 	    task.wait()
 	    expect(child:GetAttribute("Foo")).to.equal("Baz")
-	end)
+    end)
 end

--- a/test/Instances/AttributeChange.spec.lua
+++ b/test/Instances/AttributeChange.spec.lua
@@ -19,7 +19,7 @@ return function()
 		expect(changeCount).never.to.equal(0)
 	end)
 
-    it("should pass the updated value as an argument to the handler", function()
+    it("should pass the updated value as an argument", function()
         local updatedValue = ""
 		local child = New "Folder" {
 			[AttributeChange "Foo"] = function(newValue)
@@ -32,10 +32,10 @@ return function()
 		expect(updatedValue).to.equal("Baz")
     end)
 
-    it("should error when given no handler", function()
+    it("should error when given an invalid handler", function()
         expect(function()
             local child = New "Folder" {
-                [AttributeChange "Foo"] = nil
+                [AttributeChange "Foo"] = 0
             }
         end).to.throw("invalidAttributeChangeHandler")
     end)

--- a/test/Instances/AttributeChange.spec.lua
+++ b/test/Instances/AttributeChange.spec.lua
@@ -5,5 +5,38 @@ local AttributeChange = require(Package.Instances.AttributeChange)
 local Value = require(Package.State.Value)
 
 return function()
-	
+	it("should connect attribute change handlers", function()
+		local changeCount = 0
+		local child = New "Folder" {
+            [Attribute "Foo"] = "Bar",
+			[AttributeChange "Foo"] = function()
+				changeCount += 1
+			end
+		}
+
+		ins:SetAttribute("Foo", "Baz")
+		task.wait()
+		expect(changeCount).never.to.equal(0)
+	end)
+
+    it("should pass the updated value as an argument to the handler", function()
+        local updatedValue = ""
+		local child = New "Folder" {
+			[AttributeChange "Foo"] = function(newValue)
+				updatedValue = newValue
+			end
+		}
+
+		ins:SetAttribute("Foo", "Baz")
+		task.wait()
+		expect(updatedValue).to.equal("Baz")
+    end)
+
+    it("should error when given no handler", function()
+        expect(function()
+            local child = New "Folder" {
+                [AttributeChange "Foo"] = nil
+            }
+        end).to.throw("invalidAttributeChangeHandler")
+    end)
 end

--- a/test/Instances/AttributeChange.spec.lua
+++ b/test/Instances/AttributeChange.spec.lua
@@ -8,7 +8,7 @@ return function()
 	it("should connect attribute change handlers", function()
 		local changeCount = 0
 		local child = New "Folder" {
-        	[Attribute "Foo"] = "Bar",
+			[Attribute "Foo"] = "Bar",
 			[AttributeChange "Foo"] = function()
 				changeCount += 1
 			end
@@ -38,5 +38,5 @@ return function()
 				[AttributeChange "Foo"] = 0
 			}
 		end).to.throw("invalidAttributeChangeHandler")
-    end)
+	end)
 end

--- a/test/Instances/AttributeChange.spec.lua
+++ b/test/Instances/AttributeChange.spec.lua
@@ -5,34 +5,5 @@ local AttributeChange = require(Package.Instances.AttributeChange)
 local Value = require(Package.State.Value)
 
 return function()
-	it("should run when an attribute is changed", function()
-		local attribute = ""
-
-        local child = New "Folder" {
-            [Attribute "Test"] = "AttributeOne",
-			[AttributeChange "Test"] = function(newValue)
-				attribute = newValue
-			end
-		}
-		expect(attribute).to.equal("AttributeOne")
-		child:SetAttribute("Test", "AttributeTwo")
-		task.wait()
-		expect(attribute).to.equal("AttributeTwo")
-	end)
-
-	it("should update when a state value corresponding to it changes", function()
-		local attribute = Value("AttributeOne")
-		local updated = Value("")
-
-        local child = New "Folder" {
-            [Attribute "Test"] = attribute,
-			[AttributeChange "Test"] = function(newValue)
-				updated:set(newValue)
-			end
-		}
-		expect(updated:get()).to.equal("AttributeOne")
-		attribute:set("AttributeTwo")
-		task.wait()
-		expect(updated:get()).to.equal("AttributeTwo")
-	end)
+	
 end

--- a/test/Instances/AttributeChange.spec.lua
+++ b/test/Instances/AttributeChange.spec.lua
@@ -32,11 +32,11 @@ return function()
 		expect(updatedValue).to.equal("Baz")
 	end)
 
-    it("should error when given an invalid handler", function()
+	it("should error when given an invalid handler", function()
     	expect(function()
         	local child = New "Folder" {
             	[AttributeChange "Foo"] = 0
         	}
-        end).to.throw("invalidAttributeChangeHandler")
+    	end).to.throw("invalidAttributeChangeHandler")
     end)
 end

--- a/test/Instances/AttributeChange.spec.lua
+++ b/test/Instances/AttributeChange.spec.lua
@@ -8,7 +8,7 @@ return function()
 	it("should connect attribute change handlers", function()
 		local changeCount = 0
 		local child = New "Folder" {
-            [Attribute "Foo"] = "Bar",
+        	[Attribute "Foo"] = "Bar",
 			[AttributeChange "Foo"] = function()
 				changeCount += 1
 			end
@@ -19,8 +19,8 @@ return function()
 		expect(changeCount).never.to.equal(0)
 	end)
 
-    it("should pass the updated value as an argument", function()
-        local updatedValue = ""
+	it("should pass the updated value as an argument", function()
+    	local updatedValue = ""
 		local child = New "Folder" {
 			[AttributeChange "Foo"] = function(newValue)
 				updatedValue = newValue
@@ -30,13 +30,13 @@ return function()
 		child:SetAttribute("Foo", "Baz")
 		task.wait()
 		expect(updatedValue).to.equal("Baz")
-    end)
+	end)
 
     it("should error when given an invalid handler", function()
-        expect(function()
-            local child = New "Folder" {
-                [AttributeChange "Foo"] = 0
-            }
+    	expect(function()
+        	local child = New "Folder" {
+            	[AttributeChange "Foo"] = 0
+        	}
         end).to.throw("invalidAttributeChangeHandler")
     end)
 end

--- a/test/Instances/AttributeChange.spec.lua
+++ b/test/Instances/AttributeChange.spec.lua
@@ -1,0 +1,38 @@
+local Package = game:GetService("ReplicatedStorage").Fusion
+local New = require(Package.Instances.New)
+local Attribute = require(Package.Instances.Attribute)
+local AttributeChange = require(Package.Instances.AttributeChange)
+local Value = require(Package.State.Value)
+
+return function()
+	it("should run when an attribute is changed", function()
+		local attribute = ""
+
+        local child = New "Folder" {
+            [Attribute "Test"] = "AttributeOne",
+			[AttributeChange "Test"] = function(newValue)
+				attribute = newValue
+			end
+		}
+		expect(attribute).to.equal("AttributeOne")
+		child:SetAttribute("Test", "AttributeTwo")
+		task.wait()
+		expect(attribute).to.equal("AttributeTwo")
+	end)
+
+	it("should update when a state value corresponding to it changes", function()
+		local attribute = Value("AttributeOne")
+		local updated = Value("")
+
+        local child = New "Folder" {
+            [Attribute "Test"] = attribute,
+			[AttributeChange "Test"] = function(newValue)
+				updated:set(newValue)
+			end
+		}
+		expect(updated:get()).to.equal("AttributeOne")
+		attribute:set("AttributeTwo")
+		task.wait()
+		expect(updated:get()).to.equal("AttributeTwo")
+	end)
+end

--- a/test/Instances/AttributeChange.spec.lua
+++ b/test/Instances/AttributeChange.spec.lua
@@ -20,7 +20,7 @@ return function()
 	end)
 
 	it("should pass the updated value as an argument", function()
-    	local updatedValue = ""
+		local updatedValue = ""
 		local child = New "Folder" {
 			[AttributeChange "Foo"] = function(newValue)
 				updatedValue = newValue
@@ -33,10 +33,10 @@ return function()
 	end)
 
 	it("should error when given an invalid handler", function()
-    	expect(function()
-        	local child = New "Folder" {
-            	[AttributeChange "Foo"] = 0
-        	}
-    	end).to.throw("invalidAttributeChangeHandler")
+		expect(function()
+			local child = New "Folder" {
+				[AttributeChange "Foo"] = 0
+			}
+		end).to.throw("invalidAttributeChangeHandler")
     end)
 end

--- a/test/Instances/AttributeChange.spec.lua
+++ b/test/Instances/AttributeChange.spec.lua
@@ -14,7 +14,7 @@ return function()
 			end
 		}
 
-		ins:SetAttribute("Foo", "Baz")
+		child:SetAttribute("Foo", "Baz")
 		task.wait()
 		expect(changeCount).never.to.equal(0)
 	end)
@@ -27,7 +27,7 @@ return function()
 			end
 		}
 
-		ins:SetAttribute("Foo", "Baz")
+		child:SetAttribute("Foo", "Baz")
 		task.wait()
 		expect(updatedValue).to.equal("Baz")
     end)

--- a/test/Instances/AttributeOut.spec.lua
+++ b/test/Instances/AttributeOut.spec.lua
@@ -1,0 +1,3 @@
+return function ()
+    
+end

--- a/test/Instances/AttributeOut.spec.lua
+++ b/test/Instances/AttributeOut.spec.lua
@@ -1,3 +1,52 @@
+local Package = game:GetService("ReplicatedStorage").Fusion
+local New = require(Package.Instances.New)
+local Attribute = require(Package.Instances.Attribute)
+local AttributeOut = require(Package.Instances.AttributeOut)
+local Value = require(Package.State.Value)
+
 return function ()
-    
+    it("should update when attributes are changed externally", function()
+		local attributeValue = Value()
+		local child = New "Folder" {
+			[AttributeOut "Foo"] = attributeValue
+		}
+
+		expect(attributeValue:get()).to.equal(nil)
+		child:SetAttribute("Foo", "Bar")
+		task.wait()
+		expect(attributeValue:get()).to.equal("Bar")
+	end)
+
+    it("should update when state objects linked update", function()
+		local attributeValue = Value("Foo")
+        local attributeOutValue = Value()
+
+		local child = New "Folder" {
+			[Attribute "Foo"] = attributeValue,
+			[AttributeOut "Foo"] = attributeOutValue
+		}
+
+		expect(attributeOutValue:get()).to.equal("Foo")
+		attributeValue:set("Bar")
+		task.wait()
+		expect(attributeOutValue:get()).to.equal("Bar")
+    end)
+
+    it("should work with two-way connections", function()
+		local attributeValue = Value("Bar")
+		local child = New "Folder" {
+			[Attribute "Foo"] = attributeValue,
+			[AttributeOut "Foo"] = attributeValue
+		}
+
+		expect(attributeValue:get()).to.equal("Bar")
+		attributeValue:set("Baz")
+		task.wait()
+
+		expect(child:GetAttribute("Foo")).to.equal("Baz")
+		child:SetAttribute("Foo", "Biff")
+		task.wait()
+
+		expect(attributeValue:get()).to.equal("Biff")
+	end)
 end

--- a/test/Instances/AttributeOut.spec.lua
+++ b/test/Instances/AttributeOut.spec.lua
@@ -19,7 +19,7 @@ return function ()
 
 	it("should update when state objects linked update", function()
 		local attributeValue = Value("Foo")
-    	local attributeOutValue = Value()
+		local attributeOutValue = Value()
 		local child = New "Folder" {
 			[Attribute "Foo"] = attributeValue,
 			[AttributeOut "Foo"] = attributeOutValue

--- a/test/Instances/AttributeOut.spec.lua
+++ b/test/Instances/AttributeOut.spec.lua
@@ -4,7 +4,7 @@ local Attribute = require(Package.Instances.Attribute)
 local AttributeOut = require(Package.Instances.AttributeOut)
 local Value = require(Package.State.Value)
 
-return function ()
+return function()
 	it("should update when attributes are changed externally", function()
 		local attributeValue = Value()
 		local child = New "Folder" {

--- a/test/Instances/AttributeOut.spec.lua
+++ b/test/Instances/AttributeOut.spec.lua
@@ -5,7 +5,7 @@ local AttributeOut = require(Package.Instances.AttributeOut)
 local Value = require(Package.State.Value)
 
 return function ()
-    it("should update when attributes are changed externally", function()
+	it("should update when attributes are changed externally", function()
 		local attributeValue = Value()
 		local child = New "Folder" {
 			[AttributeOut "Foo"] = attributeValue
@@ -17,22 +17,20 @@ return function ()
 		expect(attributeValue:get()).to.equal("Bar")
 	end)
 
-    it("should update when state objects linked update", function()
+	it("should update when state objects linked update", function()
 		local attributeValue = Value("Foo")
-        local attributeOutValue = Value()
-
+    	local attributeOutValue = Value()
 		local child = New "Folder" {
 			[Attribute "Foo"] = attributeValue,
 			[AttributeOut "Foo"] = attributeOutValue
 		}
-
 		expect(attributeOutValue:get()).to.equal("Foo")
 		attributeValue:set("Bar")
 		task.wait()
 		expect(attributeOutValue:get()).to.equal("Bar")
-    end)
+	end)
 
-    it("should work with two-way connections", function()
+	it("should work with two-way connections", function()
 		local attributeValue = Value("Bar")
 		local child = New "Folder" {
 			[Attribute "Foo"] = attributeValue,
@@ -42,11 +40,9 @@ return function ()
 		expect(attributeValue:get()).to.equal("Bar")
 		attributeValue:set("Baz")
 		task.wait()
-
 		expect(child:GetAttribute("Foo")).to.equal("Baz")
 		child:SetAttribute("Foo", "Biff")
 		task.wait()
-
 		expect(attributeValue:get()).to.equal("Biff")
 	end)
 end

--- a/test/init.spec.lua
+++ b/test/init.spec.lua
@@ -16,6 +16,9 @@ return function()
 			Children = "table",
 			OnEvent = "function",
 			OnChange = "function",
+			Attribute = "function",
+			AttributeChange = "function",
+			AttributeOut = "function",
 
 			Value = "function",
 			Computed = "function",


### PR DESCRIPTION
This PR Implements #1 with a relatively simple API to use.
Attributes can be implemented as follows:
```lua
local stateValue = Value("AttributeValue2")

local folder = New "Folder" {
    [Attribute "AttributeName"] = "AttributeValue",
    [Attribute "AttributeName2"] = stateValue
} 
```
Attribute supports state binding, meaning if you set an attribute to a state value, it will automatically update when that state value changes.

AttributeChanged works similarly to OnChange, where you give it an attribute name, and when that attribute changes, it will run your specified callback.
```lua
local child = New "Folder" {
    [Attribute "Test"] = "AttributeOne",
    [AttributeChanged "Test"] = function(newValue)
        print("The attribute changed to", newValue) -- This will run when "Test" changes.
    end
}
```

I've also added some unit tests for attributes, however they might not be the greatest, so feel free to give any feedback for improvement!
Apologies if this PR isn't the best, I haven't done this before, however I'm open to any suggestions!
