### PR TITLE
Add immediate observer callback invokation

### DIFF
--- a/src/State/Observer.lua
+++ b/src/State/Observer.lua
@@ -63,6 +63,15 @@ function class:onChange(callback: () -> ()): () -> ()
 	end
 end
 
+--[[
+	Similar to `class:onChange()`, however it runs the provided callback
+	immediately.
+]]
+function class:onBind(callback: () -> ()): () -> ()
+	task.spawn(callback)
+	self:onChange(callback)
+end
+
 local function Observer(watchedState: PubTypes.Value<any>): Types.Observer
 	local self = setmetatable({
 		type = "State",


### PR DESCRIPTION
Solves #166 
Basically just runs the callback immediately while still providing a disconnect function.
Will be a draft for the moment until I implement disconnecting