### PR TITLE
fix: Active set to true by default on BillboardGuis

### DIFF
--- a/src/Instances/defaultProps.lua
+++ b/src/Instances/defaultProps.lua
@@ -13,7 +13,8 @@ return {
 
 	BillboardGui = {
 		ResetOnSpawn = false,
-		ZIndexBehavior = Enum.ZIndexBehavior.Sibling
+		ZIndexBehavior = Enum.ZIndexBehavior.Sibling,
+		Active = true
 	},
 
 	SurfaceGui = {


### PR DESCRIPTION
This is my suggested change for issue #213 

This pull request simply adds the property `Active` to `BillboardGui` in the default props file, rectifying the prior concern of input events not firing for descendants of the instance by default.