### PR TITLE
Improved typing for Spring

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -43,7 +43,7 @@ type Fusion = {
 	Observer: (watchedState: StateObject<any>) -> Observer,
 
 	Tween: <T>(goalState: StateObject<T>, tweenInfo: TweenInfo?) -> Tween<T>,
-	Spring: <T>(goalState: StateObject<T>, speed: number?, damping: number?) -> Spring<T>,
+	Spring: <T>(goalState: StateObject<T>, speed: CanBeState<number>?, damping: CanBeState<number>?) -> Spring<T>,
 
 	cleanup: (...any) -> (),
 	doNothing: (...any) -> (),


### PR DESCRIPTION
The documentation lists the types for speed and damping as optionally being state objects. This PR fixes the typings of Spring to match that.