### PR TITLE
fix(TweenScheduler): force RepeatCount of -1 to update tween

### DIFF
--- a/src/Animation/TweenScheduler.lua
+++ b/src/Animation/TweenScheduler.lua
@@ -46,7 +46,7 @@ local function updateAllTweens()
 	for tween: Tween in pairs(allTweens :: any) do
 		local currentTime = now - tween._currentTweenStartTime
 
-		if currentTime > tween._currentTweenDuration then
+		if currentTime > tween._currentTweenDuration and tween._currentTweenInfo.RepeatCount > -1 then
 			if tween._currentTweenInfo.Reverses then
 				tween._currentValue = tween._prevValue
 			else

--- a/src/Animation/getTweenRatio.lua
+++ b/src/Animation/getTweenRatio.lua
@@ -20,7 +20,7 @@ local function getTweenRatio(tweenInfo: TweenInfo, currentTime: number): number
 		cycleDuration += duration
 	end
 
-	if currentTime >= cycleDuration * numCycles then
+	if currentTime >= cycleDuration * numCycles and tweenInfo.RepeatCount > -1 then
 		return 1
 	end
 


### PR DESCRIPTION
This is a PR to reflect the missing changes for issue #172 that were addressed by PR #173.

I re-added the missing line, which will always force tweens with a RepeatCount of -1 to update
`if currentTime > tween._currentTweenDuration and tween._currentTweenInfo.RepeatCount > -1 then`

I'm not entirely sure how but it seems my commit for this line got removed from the git history.