### PR TITLE
Memoize certain SpecialKeys like OnEvent to allow for easy passthrough.

### DIFF
--- a/src/Instances/OnEvent.lua
+++ b/src/Instances/OnEvent.lua
@@ -9,11 +9,17 @@ local Package = script.Parent.Parent
 local PubTypes = require(Package.PubTypes)
 local logError = require(Package.Logging.logError)
 
+local memoizeTbl = setmetatable({}, {__mode = "k"})
+
 local function getProperty_unsafe(instance: Instance, property: string)
 	return (instance :: any)[property]
 end
 
 local function OnEvent(eventName: string): PubTypes.SpecialKey
+	if memoizeTbl[eventName] then
+		return memoizeTbl[eventName]
+	end
+	
 	local eventKey = {}
 	eventKey.type = "SpecialKey"
 	eventKey.kind = "OnEvent"
@@ -29,6 +35,8 @@ local function OnEvent(eventName: string): PubTypes.SpecialKey
 			table.insert(cleanupTasks, event:Connect(callback))
 		end
 	end
+
+	memoizeTbl[eventName] = eventKey
 
 	return eventKey
 end


### PR DESCRIPTION
Currently if you want to do passthrough events from one component to another, the current expected way is string indices in the props table like
```lua
myButtonComponent {
   Activated = function()
      print("do thing")
   end
}
```

My proposal is to memoize OnEvent registers so that it is easier to perform actions like the following without having to store the special key return everywhere it is needed.
```lua
local myButtonComponent(props)
   return New "TextButton" {
      [OnEvent "Activated"] = props[OnEvent "Activated"]
   }
end

myButtonComponent {
   [OnEvent "Activated"] = function
      print("do thing")
   end
}
```